### PR TITLE
Redirect git stderr to /dev/null

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=hwdata
 VERSION=$(shell awk '/Version:/ { print $$2 }' hwdata.spec)
 RELEASE=$(shell rpm -q --define 'dist %{nil}' --specfile --qf "%{release}" hwdata.spec)
-ifeq ($(shell git rev-parse --abbrev-ref HEAD | sed -n 's/^\([^0-9-]\+\).*/\L\1/p'), rhel)
+ifeq ($(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | sed -n 's/^\([^0-9-]\+\).*/\L\1/p'), rhel)
     # add revision to tag name for rhel branches
     TAGNAME := v$(VERSION)-$(RELEASE)
 else


### PR DESCRIPTION
This avoids confusing output when git is not installed.

Bug: https://bugs.gentoo.org/832461