### PR TITLE
Drop bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # -*- mode: sh -*-
 # Minimal configure script which writes out a Makefile.inc
 # Copyright 2010, 2011 Colin Walters <walters@verbum.org>
@@ -7,36 +7,18 @@
 prefix=/usr
 datarootdir=${datarootdir:-${prefix}/share}
 
-# Little helper function for reading args from the commandline.
-# it automatically handles -a b and -a=b variants, and returns 1 if
-# we need to shift $3.
-read_arg() {
-    # $1 = arg name
-    # $2 = arg value
-    # $3 = arg parameter
-    local rematch='^[^=]*=(.*)$'
-    if [[ $2 =~ $rematch ]]; then
-        read "$1" <<< "${BASH_REMATCH[1]}"
-    else
-        read "$1" <<< "$3"
-        # There is no way to shift our callers args, so
-        # return 1 to indicate they should do it instead.
-        return 1
-    fi
-}
-
-while (($# > 0)); do
-    case "${1%%=*}" in
-      	--prefix) read_arg prefix "$@" || shift;;
-      	--bindir) read_arg bindir "$@" || shift;;
-      	--sbindir) read_arg sbindir "$@" || shift;;
-      	--libexecdir) read_arg libexecdir "$@" || shift;;
-      	--datarootdir) read_arg datarootdir "$@" || shift;;
-      	--datadir) read_arg datadir "$@" || shift;;
-      	--sysconfdir) read_arg sysconfdir "$@" || shift;;
-      	--libdir) read_arg libdir "$@" || shift;;
-      	--mandir) read_arg mandir "$@" || shift;;
-	*) echo "Ignoring unknown option '$1'";;
+for arg; do
+    case "$arg" in
+        --prefix=*) prefix=${arg#*=};;
+        --bindir=*) bindir=${arg#*=};;
+        --sbindir=*) sbindir=${arg#*=};;
+        --libexecdir=*) libexecdir=${arg#*=};;
+        --datarootdir=*) datarootdir=${arg#*=};;
+        --datadir=*) datadir=${arg#*=};;
+        --sysconfdir=*) sysconfdir=${arg#*=};;
+        --libdir=*) libdir=${arg#*=};;
+        --mandir=*) mandir=${arg#*=};;
+        *) echo "Ignoring unknown option '$arg'";;
     esac
     shift
 done


### PR DESCRIPTION
bash is not portable

---
I also removed support for `./configure --prefix /usr` syntax, thereby making `=` mandatory now. However if you think that i should preserve support for it, let me know.