### PR TITLE
Optionally disable installation of the kernel blacklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ install: Makefile.inc hwdata.pc
 	for foo in $(IDFILES) ; do \
 		install -m 644 $$foo $(DESTDIR)$(datadir)/$(NAME) ;\
 	done
-	mkdir -p -m 755 $(DESTDIR)$(libdir)/modprobe.d
-	install -m 644 -T blacklist.conf $(DESTDIR)$(libdir)/modprobe.d/dist-blacklist.conf
+	@if [ "$(blacklist)" = true ]; then \
+		mkdir -p -m 755 $(DESTDIR)$(libdir)/modprobe.d ;\
+		install -m 644 -T blacklist.conf $(DESTDIR)$(libdir)/modprobe.d/dist-blacklist.conf ;\
+	fi;
 	mkdir -p -m 755 $(DESTDIR)$(datadir)/pkgconfig
 	install -m 644 hwdata.pc $(DESTDIR)$(datadir)/pkgconfig/
 

--- a/configure
+++ b/configure
@@ -6,6 +6,7 @@
 
 prefix=/usr
 datarootdir=${datarootdir:-${prefix}/share}
+blacklist=true
 
 for arg; do
     case "$arg" in
@@ -18,6 +19,7 @@ for arg; do
         --sysconfdir=*) sysconfdir=${arg#*=};;
         --libdir=*) libdir=${arg#*=};;
         --mandir=*) mandir=${arg#*=};;
+        --disable-blacklist) blacklist=false;;
         *) echo "Ignoring unknown option '$arg'";;
     esac
     shift
@@ -41,6 +43,8 @@ datadir ?= ${datadir:-${datarootdir}}
 sysconfdir ?= ${sysconfdir:-${prefix}/etc}
 libdir ?= ${libdir:-${prefix}/lib}
 mandir ?= ${mandir:-${prefix}/share/man}
+
+blacklist ?= ${blacklist}
 
 EOF
 mv Makefile.inc.tmp Makefile.inc


### PR DESCRIPTION
Adds configure option "--disable-blacklist" to optionally avoid installing of the kernel blacklist.