### PR TITLE
hwdata.pc.in: use sysroot prefix for pkgdatadir variable

### DIFF
--- a/hwdata.pc.in
+++ b/hwdata.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 datadir=@datadir@
-pkgdatadir=@pkgdatadir@
+pkgdatadir=${pc_sysrootdir}@pkgdatadir@
 
 Name: @NAME@
 Description: Hardware identification and configuration data


### PR DESCRIPTION
The pc_sysroot is automatically added to cflags and libs but not to 'pkg-config --variable'. This matches what wayland-protocols does.

Signed-off-by: Markus Volk <f_l_k@t-online.de>