### PR TITLE
usb.ids: update name for 1235:8210 (Scarlett 2i2 Gen 3)

### DIFF
--- a/usb.ids
+++ b/usb.ids
@@ -16974,7 +16974,7 @@
 	8202  Focusrite Scarlett 2i2 2nd Gen
 	8203  Focusrite Scarlett 6i6
 	8204  Scarlett 18i8 2nd Gen
-	8210  Scarlett 2i2 Camera
+	8210  Scarlett 2i2 3rd Gen
 	8211  Scarlett Solo (3rd Gen.)
 	8214  Scarlett 18i8 3rd Gen
 	8215  Scarlett 18i20 3rd Gen


### PR DESCRIPTION
1235:8210 is an Scarlett 2i2 Gen 3 audio interface, not a camera

Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>