### PR TITLE
Add script to process CSV PNP list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ iab.txt: iab.txt.utf8
 	dos2unix -n $? $@
 
 pnp.ids.orig: pnp.ids.csv
-	tail -n +2 $? | csvtool format '%(2)\t%(1)\n' - | sort -u >$@
+	./process-pnp-ids.py $? $@
 
 pnp.ids: pnp.ids.orig pnp.ids.patch
 	patch -p1 -o $@ pnp.ids.orig pnp.ids.patch

--- a/process-pnp-ids.py
+++ b/process-pnp-ids.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import sys
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process UEFI CSV output.")
+    parser.add_argument(
+        "csv_file", metavar="INPUT", type=argparse.FileType("r"), help="input CSV file"
+    )
+    parser.add_argument(
+        "output_file", metavar="OUTPUT", type=argparse.FileType("w"), help="output file"
+    )
+
+    args = parser.parse_args()
+    output_lines = []
+
+    reader = csv.DictReader(args.csv_file)
+    for row in reader:
+        if len(row) != 3:
+            print(f"Invalid line: {row}", file=sys.stderr)
+            continue
+        pnp_id = row["PNP ID"].strip()
+        company_name = row["Company"].strip()
+        if len(pnp_id) != 3:
+            print(f"PNP ID: {pnp_id}", file=sys.stderr)
+            continue
+        output_lines.append(f"{pnp_id}\t{company_name}\n")
+
+    output_lines.sort(key=str.lower)
+
+    for line in output_lines:
+        args.output_file.write(line)


### PR DESCRIPTION
The new CSV format of the PNP UEFI export includes trailing spaces in few ID stringss, which thus end up in the generated pnp.ids file. This may potentially break readers of pnp.ids, which will not get exactly a 3-length string after splitting by Tab.

To solve the problem, introduce a simply helper Python script to process the CSV UEFI file, trimming both the ID and also the company name (few had trailing spaces).

----

This only adds the scripts and the makefile changes, the actual `pnp.ids` file was not updated.