### PR TITLE
usb.ids: Fix description of 0bda:1a2b

### DIFF
--- a/usb.ids
+++ b/usb.ids
@@ -14001,7 +14001,7 @@
 	0811  Realtek 8812AU/8821AU 802.11ac WLAN Adapter [USB Wireless Dual-Band Adapter 2.4/5Ghz]
 	0821  RTL8821A Bluetooth
 	1724  RTL8723AU 802.11n WLAN Adapter
-	1a2b  RTL8188GU 802.11n WLAN Adapter (Driver CDROM Mode)
+	1a2b  Realtek WLAN Adapter (Driver CDROM Mode)
 	2831  RTL2831U DVB-T
 	2832  RTL2832U DVB-T
 	2838  RTL2838 DVB-T


### PR DESCRIPTION
This ID is used by Realtek for several different devices, such as RTL8811CU, RTL8852BU, etc, not only for RTL8188GU. Make the description more generic to avoid confusing the users.

You can see here some users who don't have RTL8188GU even though lsusb says so: https://github.com/morrownr/8821cu-20210916/issues/92