### PR TITLE
Replace `DO NOT USE` pnp vendor names. Fix #42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,8 @@ pnp.ids.orig: pnp.ids.csv
 	./process-pnp-ids.py $? $@
 
 pnp.ids: pnp.ids.orig pnp.ids.patch
-	patch -p1 -o $@ pnp.ids.orig pnp.ids.patch
+	patch -p1 -o - pnp.ids.orig pnp.ids.patch | \
+	    sed 's/\tDO NOT USE - /\tInvalid Vendor Codename - /' >$@
 
 %.utf8: %.downloaded
 	@text=`LANG=C file $?`


### PR DESCRIPTION
Using `sed` in the Makefile instead of manually editing `pnp.ids.patch` so it covers future codenames.

Using `Invalid Vendor Codename` as the replacement string, as it conveys the intended meaning and is informative enough that an end-user will (hopefully) not take it as an error or confuse with another issue.

Taking care to guard the regex within the boundaries of `\t` and ` - `, so it only matches the beginning of the Vendor names with that specific pattern.