### PR TITLE
Fix issues in usb.ids

### DIFF
--- a/01-utf-8-encoding.patch.patch
+++ b/01-utf-8-encoding.patch.patch
@@ -1,0 +1,11 @@
+--- usb.ids.orig	2025-02-10 12:18:44.961357388 +0100
++++ usb.ids	2025-02-10 12:20:17.220507456 +0100
+@@ -24479,7 +24479,7 @@
+ 	031  \ and | (Backslash and Bar)
+ 	032  # and ~ (Hash and Tilde, Non-US Keyboard near right shift)
+ 	033  ; and : (Semicolon and Colon)
+-	034  ´ and " (Accent Acute and Double Quotes)
++	034  Â´ and " (Accent Acute and Double Quotes)
+ 	035  ` and ~ (Accent Grace and Tilde)
+ 	036  , and < (Comma and Less)
+ 	037  . and > (Period and Greater)

--- a/02-typos.patch.patch
+++ b/02-typos.patch.patch
@@ -1,0 +1,111 @@
+--- usb.ids.orig	2025-02-10 12:20:17.220507456 +0100
++++ usb.ids	2025-02-10 12:21:14.926984411 +0100
+@@ -24086,7 +24086,7 @@
+ AT 0201  Microphone
+ AT 0202  Desktop Microphone
+ AT 0203  Personal Microphone
+-AT 0204  Omni-directional Microphone
++AT 0204  Omni-Directional Microphone
+ AT 0205  Microphone Array
+ AT 0206  Processing Microphone Array
+ AT 0300  Output Undefined
+@@ -24101,8 +24101,8 @@
+ AT 0401  Handset
+ AT 0402  Headset
+ AT 0403  Speakerphone, no echo reduction
+-AT 0404  Echo-suppressing speakerphone
+-AT 0405  Echo-canceling speakerphone
++AT 0404  Echo-Suppressing Speakerphone
++AT 0405  Echo-Canceling Speakerphone
+ AT 0500  Telephony Undefined
+ AT 0501  Phone line
+ AT 0502  Telephone
+@@ -24324,7 +24324,7 @@
+ 	0b9  Elevator Trim
+ 	0ba  Rudder
+ 	0bb  Throttle
+-	0bc  Flight COmmunications
++	0bc  Flight Communications
+ 	0bd  Flare Release
+ 	0be  Landing Gear
+ 	0bf  Toe Break
+@@ -24341,8 +24341,8 @@
+ 	0ca  Barrel Elevation
+ 	0cb  Drive Plane
+ 	0cc  Ballast
+-	0cd  Bicylce Crank
+-	0ce  Handle Bars
++	0cd  Bicycle Crank
++	0ce  Handlebars
+ 	0cf  Front Brake
+ 	0d0  Rear Brake
+ HUT 03  VR Controls
+@@ -24614,7 +24614,7 @@
+ 	00b  High Cut Filter
+ 	00c  Low Cut Filter
+ 	00d  Equalizer Enable
+-	00e  Sound Field ON
++	00e  Sound Field On
+ 	00f  Surround On
+ 	010  Repeat
+ 	011  Stereo
+@@ -25157,7 +25157,7 @@
+ 	02d  Display Status
+ 	02e  Stat Not Ready
+ 	02f  Stat Ready
+-	030  Err Not a loadable Character
++	030  Err Not a Loadable Character
+ 	031  Err Font Data Cannot Be Read
+ 	032  Cursur Position Report
+ 	033  Row
+@@ -25425,14 +25425,14 @@
+ 	04  Libya
+ 	05  Algeria
+ 	06  Morocco
+-	07  Tunesia
++	07  Tunisia
+ 	08  Oman
+ 	09  Yemen
+ 	0a  Syria
+ 	0b  Jordan
+ 	0c  Lebanon
+ 	0d  Kuwait
+-	0e  U.A.E
++	0e  U.A.E.
+ 	0f  Bahrain
+ 	10  Qatar
+ L 0002  Bulgarian
+@@ -25461,7 +25461,7 @@
+ 	06  Ireland
+ 	07  South Africa
+ 	08  Jamaica
+-	09  Carribean
++	09  Caribbean
+ 	0a  Belize
+ 	0b  Trinidad
+ 	0c  Zimbabwe
+@@ -25497,7 +25497,7 @@
+ 	06  Monaco
+ L 000d  Hebrew
+ L 000e  Hungarian
+-L 000f  Idelandic
++L 000f  Icelandic
+ L 0010  Italian
+ 	01  Italian
+ 	02  Swiss
+@@ -25551,13 +25551,13 @@
+ L 002f  Macedonian
+ L 0036  Afrikaans
+ L 0037  Georgian
+-L 0038  Faeroese
++L 0038  Faroese
+ L 0039  Hindi
+ L 003e  Malay
+ 	01  Malaysia
+ 	02  Brunei Darassalam
+ L 003f  Kazak
+-L 0041  Awahili
++L 0041  Swahili
+ L 0043  Uzbek
+ 	01  Latin
+ 	02  Cyrillic


### PR DESCRIPTION
Apply Debian patches fixing usb.ids encoding and a couple of typos (patch by Peter Samuelson <peters@p12n.org>).

Add usb.ids to check that the file is valid UTF-8.

Fixes https://github.com/vcrhonek/hwdata/issues/50