### PR TITLE
Update pci and vendor ids

### DIFF
--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.396
+Version: 0.397
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Tue Jul 01 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.397-1
+- Update pci and vendor ids
+
 * Mon Jun 02 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.396-1
 - Update pci and vendor ids
 

--- a/iab.txt
+++ b/iab.txt
@@ -2387,12 +2387,6 @@ B65000-B65FFF                 (base 16)                     Peek Traffic Corpora
                                                             Palmetto  Florida  34221
                                                             US
 
-00-50-C2                      (hex)                         Efftronics Systems (P) Ltd
-B45000-B45FFF                 (base 16)                     Efftronics Systems (P) Ltd
-                                                            40-15-9
-                                                            Vijayawada  Andhra Pradesh  520010
-                                                            IN
-
 00-50-C2                      (hex)                         Sound Metrics Corp
 B6D000-B6DFFF                 (base 16)                     Sound Metrics Corp
                                                             15029 Bothell Way NE
@@ -5497,6 +5491,12 @@ A59000-A59FFF                 (base 16)                     Televic Rail GmbH
                                                             PO Box 1007
                                                             Sioux Falls  SD  57104
                                                             US
+
+00-50-C2                      (hex)                         Efftronics Systems (P) Ltd
+B45000-B45FFF                 (base 16)                     Efftronics Systems (P) Ltd
+                                                            Plot No.4, IT Park, Auto Nagar
+                                                            Mangalagiri  Andhra Pradesh  520010
+                                                            IN
 
 00-50-C2                      (hex)                         Cleaveland/Price, Inc.
 93B000-93BFFF                 (base 16)                     Cleaveland/Price, Inc.

--- a/pci.ids
+++ b/pci.ids
@@ -1,8 +1,8 @@
 #
 #	List of PCI ID's
 #
-#	Version: 2025.05.27
-#	Date:    2025-05-27 03:15:02
+#	Version: 2025.06.21
+#	Date:    2025-06-21 17:54:14
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -653,7 +653,7 @@
 		1bd4 000e  6G SAS2008IR
 		1bd4 000f  6G SAS2008IT SA5248
 		1bd4 0010  6G SAS2008IR SA5248
-		4c52 96c8  LRSA96C8 8-Port SATA3(6Gb/s)Exchange Adapter (with Raid)
+		4c52 96c8  LRSA96C8 8-Port SATA3 (6Gb/s) Exchange Adapter (with RAID)
 		8086 350f  RMS2LL040 RAID Controller
 		8086 3700  SSD 910 Series
 	0073  MegaRAID SAS 2008 [Falcon]
@@ -1326,8 +1326,9 @@
 	1681  Rembrandt [Radeon 680M]
 	1714  BeaverCreek HDMI Audio [Radeon HD 6500D and 6400G-6600G series]
 		103c 168b  ProBook 4535s
-	1900  Phoenix3
-	1901  Phoenix4
+	1900  HawkPoint1
+	1901  HawkPoint2
+	1902  Krackan2
 	3150  RV380/M24 [Mobility Radeon X600]
 		103c 0934  nx8220
 	3151  RV380 GL [FireMV 2400]
@@ -4117,15 +4118,20 @@
 	7489  Navi 33 [Radeon Pro W7500]
 	748b  Navi 33 [Radeon Graphics]
 	7499  Navi 33 [Radeon RX 7400/7300/Pro W7400]
+	749f  Navi 33 [Radeon RX 7500]
 	74a0  Aqua Vanjaram [Instinct MI300A]
 	74a1  Aqua Vanjaram [Instinct MI300X]
 	74a2  Aqua Vanjaram [Instinct MI308X]
 	74a5  Aqua Vanjaram [Instinct MI325X]
 	74a9  Aqua Vanjaram [Instinct MI300X HF]
 	74b5  Aqua Vanjaram [Instinct MI300X VF]
+	74b9  Aqua Vanjaram [Instinct MI325X VF]
 	74bd  Aqua Vanjaram [Instinct MI300X HF]
-	7550  Navi 48 [RX 9070/9070 XT]
+	7550  Navi 48 [Radeon RX 9070/9070 XT/9070 GRE]
+		148c 2435  Reaper Radeon RX 9070 XT 16GB GDDR6 (RX9070XT 16G-A)
 		1da2 e490  Navi 48 XTX [Sapphire Pulse Radeon RX 9070 XT]
+	7551  Navi 48 [Radeon AI PRO R9700]
+	7590  Navi 44 [Radeon RX 9060 XT]
 	7833  RS350 Host Bridge
 	7834  RS350 [Radeon 9100 PRO/XT IGP]
 	7835  RS350M [Mobility Radeon 9000 IGP]
@@ -4530,6 +4536,7 @@
 	ab28  Navi 21/23 HDMI/DP Audio Controller
 	ab30  Navi 31 HDMI/DP Audio
 	ab38  Navi 10 HDMI Audio
+	ab40  Navi 48 HDMI/DP Audio Controller
 	ac00  Theater 506 World-Wide Analog Decoder
 	ac01  Theater 506 World-Wide Analog Decoder
 	ac02  TV Wonder HD 600 PCIe
@@ -5687,6 +5694,7 @@
 	43c8  400 Series Chipset SATA Controller
 	43d5  400 Series Chipset USB 3.1 xHCI Compliant Host Controller
 	43e9  500 Series Chipset Switch Upstream Port
+	43ea  500 Series Chipset Switch Downstream Port
 	43eb  500 Series Chipset SATA Controller
 # or ASM106X Serial ATA Controller
 		1b21 1062  ASM1062 Serial ATA Controller
@@ -7261,6 +7269,7 @@
 	8004  DTL-H2500 [Playstation development board]
 	8009  CXD1947Q i.LINK Controller
 	800c  DTL-H800 [PS1 sound development board]
+	800d  DVBK-2000(E) DV Still Image Capture Board
 	8039  CXD3222 i.LINK Controller
 	8047  PS2 TOOL MRP
 	8056  Rockwell HCF 56K modem
@@ -13454,6 +13463,8 @@
 	2c18  GB203M / GN22 [GeForce RTX 5090 Max-Q / Mobile]
 	2c19  GB203M / GN22 [GeForce RTX 5080 Max-Q / Mobile]
 	2c2c  GB6-256(N22W-ES-A1)
+	2c38  GB203GLM [RTX PRO 5000 Blackwell Generation Laptop GPU]
+	2c39  GB203GLM [RTX PRO 4000 Blackwell Generation Laptop GPU]
 	2c58  GB203M / GN22-X11 [GeForce RTX 5090 Max-Q / Mobile]
 	2c59  GB203M / GN22-X9 [GeForce RTX 5080 Max-Q / Mobile]
 	2d04  GB206 [GeForce RTX 5060 Ti]
@@ -13461,13 +13472,17 @@
 	2d18  GB206M [GeForce RTX 5070 Max-Q / Mobile]
 	2d19  GB206M [GeForce RTX 5060 Max-Q / Mobile]
 	2d2c  GB6-128 (N22Y-ES-A1)
+	2d39  GB206GLM [RTX PRO 2000 Blackwell Generation Laptop GPU]
 	2d58  GB206M [GeForce RTX 5070 Max-Q / Mobile]
 	2d59  GB206M [GeForce RTX 5060 Max-Q / Mobile]
 	2d98  GB207M [GeForce RTX 5050 Max-Q / Mobile]
+	2db8  GB207GLM [RTX PRO 1000 Blackwell Generation Laptop GPU]
+	2db9  GB207GLM [RTX PRO 500 Blackwell Generation Laptop GPU]
 	2dd8  GB207M [GeForce RTX 5050 Max-Q / Mobile]
 	2e2a  GB20B
 	2f04  GB205 [GeForce RTX 5070]
 	2f18  GB205M [GeForce RTX 5070 Ti Mobile]
+	2f38  GB205GLM [RTX PRO 3000 Blackwell Generation Laptop GPU]
 	2f58  GB205M [GeForce RTX 5070 Ti Mobile]
 	31c0  GB110
 	3340  GB120
@@ -14747,7 +14762,7 @@
 	5419  VN1000 I/O APIC Interrupt Controller
 	6100  VT85C100A [Rhine II]
 	6122  VN1000 Graphics [Chrome 520 IGP]
-	6287  SATA RAID Controller
+	6287  VT8251 AHCI SATA Controller
 	6290  K8M890CE Host Bridge
 	6327  P4M890 Security Device
 	6353  VX800/VX820 Scratch Registers
@@ -22609,6 +22624,7 @@
 # NIC-ETH540F-3S-2P OCP3.0 2x10G Card
 		193d 1084  NIC-ETH540F-3S-2P
 		1e81 0c10  25GbE dual-port SFP28, PCIe3.0 x8 [3SC10]
+		1f3f 0c10  25GbE dual-port SFP28, PCIe3.0 x8, 3SC10
 	1016  MT27710 Family [ConnectX-4 Lx Virtual Function]
 	1017  MT27800 Family [ConnectX-5]
 		117c 00b1  FastFrame N311 Single-port 10Gb Ethernet Adapter
@@ -22635,6 +22651,7 @@
 		193d 1035  NIC-ETH641F-LP-2P SFP28 2x25GbE PCIe Network Adapter
 		1bd4 00ac  O252MCX6Lx
 		1bd4 00ae  S252MCX6Lx
+		1f3f 0c11  25GbE dual-port SFP28, PCIe4.0 x8, 3SC1125GbE dual-port SFP28, PCIe4.0 x8, 3SC11
 		1ff9 00ad  ENFM6251-SP2
 		1ff9 00af  ENPM6251-SP2
 	1020  MT28860
@@ -25220,7 +25237,11 @@
 	1112  AR9285 Wireless Network Adapter (PCI-Express)
 1a3e  Micro-Research Finland Oy
 	132c  MTCA Event Receiver 300
+	152c  CompactPCI Event Receiver 300
+	172c  PCI Express Event Receiver 300
+	192c  CompactPCI Event Receiver TG 300
 	232c  MTCA Event Master 300
+	252c  CompactPCI Event Generator 300
 1a41  Tilera Corp.
 	0001  TILE64 processor
 	0002  TILEPro processor
@@ -25442,21 +25463,83 @@
 	1005  Virtio RNG
 	1009  Virtio filesystem
 	1041  Virtio 1.0 network device
+		1af4 1100  QEMU
 	1042  Virtio 1.0 block device
+		1af4 1100  QEMU
 	1043  Virtio 1.0 console
+		1af4 1100  QEMU
 	1044  Virtio 1.0 RNG
-	1045  Virtio 1.0 memory balloon
+		1af4 1100  QEMU
+	1045  Virtio 1.0 balloon
+		1af4 1100  QEMU
+	1046  Virtio 1.0 ioMemory
+		1af4 1100  QEMU
+	1047  Virtio 1.0 remote processor messaging
+		1af4 1100  QEMU
 	1048  Virtio 1.0 SCSI
-	1049  Virtio 1.0 filesystem
+		1af4 1100  QEMU
+	1049  Virtio 9P transport
+		1af4 1100  QEMU
+	104a  Virtio 1.0 WLAN MAC
+		1af4 1100  QEMU
+	104b  Virtio 1.0 remoteproc serial link
+		1af4 1100  QEMU
+	104d  Virtio 1.0 memory balloon
+		1af4 1100  QEMU
 	1050  Virtio 1.0 GPU
+		1af4 1100  QEMU
+	1051  Virtio 1.0 clock/timer
+		1af4 1100  QEMU
 	1052  Virtio 1.0 input
+		1af4 1100  QEMU
 	1053  Virtio 1.0 socket
+		1af4 1100  QEMU
 	1054  Virtio 1.0 crypto
-	1058  virtio-mem
+		1af4 1100  QEMU
+	1055  Virtio 1.0 signal distribution device
+		1af4 1100  QEMU
+	1056  Virtio 1.0 pstore device
+		1af4 1100  QEMU
+	1057  Virtio 1.0 IOMMU
+		1af4 1100  QEMU
+	1058  Virtio 1.0 mem
+		1af4 1100  QEMU
 	1059  Virtio 1.0 sound
-	105a  Virtio file system
-	1110  Inter-VM shared memory
-		1af4 1100  QEMU Virtual Machine
+		1af4 1100  QEMU
+	105a  Virtio 1.0 file system
+		1af4 1100  QEMU
+	105b  Virtio 1.0 pmem
+		1af4 1100  QEMU
+	105c  Virtio 1.0 rpmb
+		1af4 1100  QEMU
+	105d  Virtio 1.0 mac80211-hwsim
+		1af4 1100  QEMU
+	105e  Virtio 1.0 video encoder
+		1af4 1100  QEMU
+	105f  Virtio 1.0 video decoder
+		1af4 1100  QEMU
+	1060  Virtio 1.0 SCMI
+		1af4 1100  QEMU
+	1061  Virtio 1.0 nitro secure module
+		1af4 1100  QEMU
+	1062  Virtio 1.0 I2C adapter
+		1af4 1100  QEMU
+	1063  Virtio 1.0 watchdog
+		1af4 1100  QEMU
+	1064  Virtio 1.0 can
+		1af4 1100  QEMU
+	1065  Virtio 1.0 dmabuf
+		1af4 1100  QEMU
+	1066  Virtio 1.0 parameter server
+		1af4 1100  QEMU
+	1067  Virtio 1.0 audio policy
+		1af4 1100  QEMU
+	1068  Virtio 1.0 Bluetooth
+		1af4 1100  QEMU
+	1069  Virtio 1.0 GPIO
+		1af4 1100  QEMU
+	1110  QEMU Inter-VM shared memory device
+		1af4 1100  QEMU
 1af5  Netezza Corp.
 1afa  J & W Electronics Co., Ltd.
 1b00  Montage Technology Co., Ltd.
@@ -25852,6 +25935,7 @@
 	5026  FireCuda 540 SSD
 	5027  LaCie Rugged SSD Pro5
 	5100  PCIe Gen3 SSD
+	5101  PCIe Gen5 SSD
 1bb3  Bluecherry
 	4304  BC-04120A MPEG4 4 port video encoder / decoder
 	4309  BC-08240A MPEG4 4 port video encoder / decoder
@@ -26414,6 +26498,7 @@
 	0002  Pro Capture AIO
 	0010  Pro Capture Endpoint
 	0014  PRO CAPTURE AIO 4K PLUS
+	0015  Pro Capture HDMI 4K +
 	0017  PRO CAPTURE AIO 4K
 	0051  Eco Capture Dual HDMI M.2
 	0052  Eco Capture HDMI 4K M.2
@@ -26466,14 +26551,6 @@
 	806d  NX I512 RDMA PF Ethernet Controller
 	806e  NX I512 RDMA VF Ethernet Controller Virtual Function
 	806f  NX I512 UPF BOND PF Ethernet Controller
-	8075  NX VGCF BOND0 PF Ethernet Controller
-	8076  NX VGCF NE0 PF Ethernet Controller
-	8077  NX VGCF NE0 VF Ethernet Controller Virtual Function
-	8078  NX VGCF BOND1 PF Ethernet Controller
-	8079  NX VGCF NE1 PF Ethernet Controller
-	807a  NX VGCF NE1 VF Ethernet Controller Virtual Function
-	807b  NX VGCF NE2 PF Ethernet Controller
-	807c  NX VGCF NE2 VF Ethernet Controller Virtual Function
 	807d  NX E312S SRIOV PF Ethernet Controller
 	807e  NX E316 SRIOV PF Ethernet Controller
 	807f  NX E316 SRIOV VF Ethernet Controller Virtual Function
@@ -27274,7 +27351,7 @@
 	2000  NoLoad Hardware Development Kit
 	3000  eBPF-based PCIe Accelerator
 1ded  Alibaba (China) Co., Ltd.
-	107f  Alibaba Elastic RDMA Adapter
+	107f  Elastic RDMA Adapter
 	5007  Elastic RDMA Adapter
 	8000  M1 Root Port
 	8001  ACC-RCiEP
@@ -27297,6 +27374,14 @@
 		1dee 0012  NVMe SSD SP406 3.84T 2.5" U.2
 		1dee 0013  NVMe SSD SP406 7.68T 2.5" U.2
 	5161  BIWIN NVMe SSD SP506/SP516
+		1dee 0001  NVMe SSD SP516 1.6T 2.5" U.2
+		1dee 0002  NVMe SSD SP516 3.2T 2.5" U.2
+		1dee 0003  NVMe SSD SP516 6.4T 2.5" U.2
+		1dee 0004  NVMe SSD SP516 12.8T 2.5" U.2
+		1dee 0011  NVMe SSD SP506 1.92T 2.5" U.2
+		1dee 0012  NVMe SSD SP506 3.84T 2.5" U.2
+		1dee 0013  NVMe SSD SP506 7.68T 2.5" U.2
+		1dee 0014  NVMe SSD SP506 15.36T 2.5" U.2
 	5216  KingSpec NX series NVMe SSD (DRAM-less)
 	7700  BIWIN NVMe SSD SP50Y/SP51Y
 1def  Ampere Computing, LLC
@@ -27564,8 +27649,8 @@
 	c033  S60G [Enflame]
 # FHFL PCIe card, dual slot, 3rd generation from Enflame, 48GB device memory
 	c035  S60 [Enflame]
-	c041  L300 AI module [Enflame]
-	c042  L600 AI module [Enflame]
+	c041  L300 [Enflame]
+	c042  L600 [Enflame]
 # nee Thinci, Inc
 1e38  Blaize, Inc
 	0102  Xplorer X1600
@@ -27794,6 +27879,7 @@
 	7010  AI controller A7010
 1e60  Hailo Technologies Ltd.
 	2864  Hailo-8 AI Processor
+	45c4  Hailo-10H AI Processor
 1e67  Untether AI
 	0002  runAI200 AI Inference Accelerator
 	0004  speedAI240 AI Inference Accelerator
@@ -27843,6 +27929,11 @@
 	1005  PLEXTOR M10P(GN) NVMe SSD M.2
 	1007  CL4-8D512 NVMe SSD M.2 (DRAM-less)
 	1008  CL5-8D512 NVMe SSD M.2 (DRAM-less)
+	1010  CX3 Series NVMe SSD
+		1e95 0000  M.2 2280 480 GB
+		1e95 0001  M.2 2280 960 GB
+		1e95 0002  M.2 2280 1,920 GB
+		1e95 0003  M.2 2280 3,840 GB
 	3500  CA5-8D256 NVMe SSD M.2
 	35f1  PLEXTOR M9PGN Plus NVMe SSD M.2
 	9100  CL1-3D256-Q11 NVMe SSD M.2
@@ -28027,6 +28118,18 @@
 		1ee4 0425  NVMe SSD U.2 1.6TB (P8118Z3)
 		1ee4 0426  NVMe SSD U.2 3.2TB (P8118Z3)
 		1ee4 0427  NVMe SSD U.2 6.4TB (P8118Z3)
+		1ee4 0515  NVMe SSD U.2 1.92TB (P8118Z4)
+		1ee4 0516  NVMe SSD U.2 3.84TB (P8118Z4)
+		1ee4 0517  NVMe SSD U.2 7.68TB (P8118Z4)
+		1ee4 0525  NVMe SSD U.2 1.6TB (P8118Z4)
+		1ee4 0526  NVMe SSD U.2 3.2TB (P8118Z4)
+		1ee4 0527  NVMe SSD U.2 6.4TB (P8118Z4)
+		1ee4 0615  NVMe SSD U.2 1.92TB (P8128Z3)
+		1ee4 0616  NVMe SSD U.2 3.84TB (P8128Z3)
+		1ee4 0617  NVMe SSD U.2 7.68TB (P8128Z3)
+		1ee4 0625  NVMe SSD U.2 1.6TB (P8128Z3)
+		1ee4 0626  NVMe SSD U.2 3.2TB (P8128Z3)
+		1ee4 0627  NVMe SSD U.2 6.4TB (P8128Z3)
 		1ee4 3013  NVMe SSD AIC 480GB (P8118E)
 		1ee4 3014  NVMe SSD AIC 960GB (P8118E)
 		1ee4 3015  NVMe SSD AIC 1.92TB (P8118E)
@@ -28051,6 +28154,30 @@
 		1ee4 3225  NVMe SSD AIC 1.6TB (P8118X)
 		1ee4 3226  NVMe SSD AIC 3.2TB (P8118X)
 		1ee4 3227  NVMe SSD AIC 6.4TB (P8118X)
+		1ee4 3315  NVMe SSD AIC 1.92TB (P8118E4)
+		1ee4 3316  NVMe SSD AIC 3.84TB (P8118E4)
+		1ee4 3317  NVMe SSD AIC 7.68TB (P8118E4)
+		1ee4 3325  NVMe SSD AIC 1.6TB (P8118E4)
+		1ee4 3326  NVMe SSD AIC 3.2TB (P8118E4)
+		1ee4 3327  NVMe SSD AIC 6.4TB (P8118E4)
+		1ee4 3415  NVMe SSD AIC 1.92TB (P8118Z3)
+		1ee4 3416  NVMe SSD AIC 3.84TB (P8118Z3)
+		1ee4 3417  NVMe SSD AIC 7.68TB (P8118Z3)
+		1ee4 3425  NVMe SSD AIC 1.6TB (P8118Z3)
+		1ee4 3426  NVMe SSD AIC 3.2TB (P8118Z3)
+		1ee4 3427  NVMe SSD AIC 6.4TB (P8118Z3)
+		1ee4 3515  NVMe SSD AIC 1.92TB (P8118Z4)
+		1ee4 3516  NVMe SSD AIC 3.84TB (P8118Z4)
+		1ee4 3517  NVMe SSD AIC 7.68TB (P8118Z4)
+		1ee4 3525  NVMe SSD AIC 1.6TB (P8118Z4)
+		1ee4 3526  NVMe SSD AIC 3.2TB (P8118Z4)
+		1ee4 3527  NVMe SSD AIC 6.4TB (P8118Z4)
+		1ee4 3615  NVMe SSD AIC 1.92TB (P8128Z3)
+		1ee4 3616  NVMe SSD AIC 3.84TB (P8128Z3)
+		1ee4 3617  NVMe SSD AIC 7.68TB (P8128Z3)
+		1ee4 3625  NVMe SSD AIC 1.6TB (P8128Z3)
+		1ee4 3626  NVMe SSD AIC 3.2TB (P8128Z3)
+		1ee4 3627  NVMe SSD AIC 6.4TB (P8128Z3)
 		1ee4 abcd  NVMe SSD U.2
 	1181  PETA8118 NVMe E1S Series
 		1ee4 2015  NVMe SSD E1.S 1.92TB (P8118E)
@@ -28071,6 +28198,30 @@
 		1ee4 2225  NVMe SSD E1.S 1.6TB (P8118X)
 		1ee4 2226  NVMe SSD E1.S 3.2TB (P8118X)
 		1ee4 2227  NVMe SSD E1.S 6.4TB (P8118X)
+		1ee4 2315  NVMe SSD E1.S 1.92TB (P8118E4)
+		1ee4 2316  NVMe SSD E1.S 3.84TB (P8118E4)
+		1ee4 2317  NVMe SSD E1.S 7.68TB (P8118E4)
+		1ee4 2325  NVMe SSD E1.S 1.6TB (P8118E4)
+		1ee4 2326  NVMe SSD E1.S 3.2TB (P8118E4)
+		1ee4 2327  NVMe SSD E1.S 6.4TB (P8118E4)
+		1ee4 2415  NVMe SSD E1.S 1.92TB (P8118Z3)
+		1ee4 2416  NVMe SSD E1.S 3.84TB (P8118Z3)
+		1ee4 2417  NVMe SSD E1.S 7.68TB (P8118Z3)
+		1ee4 2425  NVMe SSD E1.S 1.6TB (P8118Z3)
+		1ee4 2426  NVMe SSD E1.S 3.2TB (P8118Z3)
+		1ee4 2427  NVMe SSD E1.S 6.4TB (P8118Z3)
+		1ee4 2515  NVMe SSD E1.S 1.92TB (P8118Z4)
+		1ee4 2516  NVMe SSD E1.S 3.84TB (P8118Z4)
+		1ee4 2517  NVMe SSD E1.S 7.68TB (P8118Z4)
+		1ee4 2525  NVMe SSD E1.S 1.6TB (P8118Z4)
+		1ee4 2526  NVMe SSD E1.S 3.2TB (P8118Z4)
+		1ee4 2527  NVMe SSD E1.S 6.4TB (P8118Z4)
+		1ee4 2615  NVMe SSD E1.S 1.92TB (P8128Z3)
+		1ee4 2616  NVMe SSD E1.S 3.84TB (P8128Z3)
+		1ee4 2617  NVMe SSD E1.S 7.68TB (P8128Z3)
+		1ee4 2625  NVMe SSD E1.S 1.6TB (P8128Z3)
+		1ee4 2626  NVMe SSD E1.S 3.2TB (P8128Z3)
+		1ee4 2627  NVMe SSD E1.S 6.4TB (P8128Z3)
 	1182  PETA8118 NVMe M2 Series
 		1ee4 1013  NVMe SSD M.2 480GB (P8118E)
 		1ee4 1014  NVMe SSD M.2 960GB (P8118E)
@@ -28096,6 +28247,46 @@
 		1ee4 1224  NVMe SSD M.2 800GB (P8118X)
 		1ee4 1225  NVMe SSD M.2 1.6TB (P8118X)
 		1ee4 1226  NVMe SSD M.2 3.2TB (P8118X)
+		1ee4 1313  NVMe SSD M.2 480GB (P8118E4)
+		1ee4 1314  NVMe SSD M.2 960GB (P8118E4)
+		1ee4 1315  NVMe SSD M.2 1.92TB (P8118E4)
+		1ee4 1316  NVMe SSD M.2 3.84TB (P8118E4)
+		1ee4 1317  NVMe SSD M.2 7.68TB (P8118E4)
+		1ee4 1323  NVMe SSD M.2 400GB (P8118E4)
+		1ee4 1324  NVMe SSD M.2 800GB (P8118E4)
+		1ee4 1325  NVMe SSD M.2 1.6TB (P8118E4)
+		1ee4 1326  NVMe SSD M.2 3.2TB (P8118E4)
+		1ee4 1327  NVMe SSD M.2 6.4TB (P8118E4)
+		1ee4 1413  NVMe SSD M.2 480GB (P8118Z3)
+		1ee4 1414  NVMe SSD M.2 960GB (P8118Z3)
+		1ee4 1415  NVMe SSD M.2 1.92TB (P8118Z3)
+		1ee4 1416  NVMe SSD M.2 3.84TB (P8118Z3)
+		1ee4 1417  NVMe SSD M.2 7.68TB (P8118Z3)
+		1ee4 1423  NVMe SSD M.2 400GB(P8118Z3)
+		1ee4 1424  NVMe SSD M.2 800GB (P8118Z3)
+		1ee4 1425  NVMe SSD M.2 1.6TB (P8118Z3)
+		1ee4 1426  NVMe SSD M.2 3.2TB (P8118Z3)
+		1ee4 1427  NVMe SSD M.2 6.4TB (P8118Z3)
+		1ee4 1513  NVMe SSD M.2 480GB (P8118Z4)
+		1ee4 1514  NVMe SSD M.2 960GB (P8118Z4)
+		1ee4 1515  NVMe SSD M.2 1.92TB (P8118Z4)
+		1ee4 1516  NVMe SSD M.2 3.84TB (P8118Z4)
+		1ee4 1517  NVMe SSD M.2 7.68TB (P8118Z4)
+		1ee4 1523  NVMe SSD M.2 400GB (P8118Z4)
+		1ee4 1524  NVMe SSD M.2 800GB (P8118Z4)
+		1ee4 1525  NVMe SSD M.2 1.6TB (P8118Z4)
+		1ee4 1526  NVMe SSD M.2 3.2TB (P8118Z4)
+		1ee4 1527  NVMe SSD M.2 6.4TB (P8118Z4)
+		1ee4 1613  NVMe SSD M.2 480GB (P8128Z3)
+		1ee4 1614  NVMe SSD M.2 960GB (P8128Z3)
+		1ee4 1615  NVMe SSD M.2 1.92TB (P8128Z3)
+		1ee4 1616  NVMe SSD M.2 3.84TB (P8128Z3)
+		1ee4 1617  NVMe SSD M.2 7.68TB (P8128Z3)
+		1ee4 1623  NVMe SSD M.2 400GB (P8128Z3)
+		1ee4 1624  NVMe SSD M.2 800GB (P8128Z3)
+		1ee4 1625  NVMe SSD M.2 1.6TB (P8128Z3)
+		1ee4 1626  NVMe SSD M.2 3.2TB (P8128Z3)
+		1ee4 1627  NVMe SSD M.2 6.4TB (P8128Z3)
 1ee9  SUSE LLC
 1eec  Viscore Technologies Ltd
 	0102  VSE250231S Dual-port 10Gb/25Gb Ethernet PCIe
@@ -28279,18 +28470,18 @@
 1f44  VVDN Technologies Private Limited
 1f47  YUSUR Technology Co., Ltd.
 	1001  FLEXFLOW-2200T Ethernet Controller
-		1f47 0001  FLEXFLOW-2200T Ethernet 10G 2P
-		1f47 0002  FLEXFLOW-2200T Ethernet 25G 2P
-		1f47 0003  FLEXFLOW-2200T Ethernet 40G 2P
-		1f47 0004  FLEXFLOW-2200T Ethernet 100G 1P
-		1f47 0005  FLEXFLOW-2200T Ethernet 100G 2P
-		1f47 0006  FLEXFLOW-2200T Ethernet 10G 2P
-		1f47 0007  FLEXFLOW-2200T Ethernet 25G 2P
-		1f47 0008  FLEXFLOW-2200T Ethernet 40G 2P
-		1f47 0009  FLEXFLOW-2200T Ethernet 100G 1P
-		1f47 000a  FLEXFLOW-2200T Ethernet 100G 2P
-	1002  FLEXFLOW-2200T Ethernet Controller (Virtual Function)
-	1003  FLEXFLOW-2200T Ethernet Controller MGMT Function
+		1f47 0001  Ethernet 10G 2P FLEXFLOW-2200T
+		1f47 0002  Ethernet 25G 2P FLEXFLOW-2200T
+		1f47 0003  Ethernet 40G 2P FLEXFLOW-2200T
+		1f47 0004  Ethernet 100G 1P FLEXFLOW-2200T
+		1f47 0005  Ethernet 100G 2P FLEXFLOW-2200T
+		1f47 0006  Ethernet 10G 2P FLEXFLOW-2200T
+		1f47 0007  Ethernet 25G 2P FLEXFLOW-2200T
+		1f47 0008  Ethernet 40G 2P FLEXFLOW-2200T
+		1f47 0009  Ethernet 100G 1P FLEXFLOW-2200T
+		1f47 000a  Ethernet 100G 2P FLEXFLOW-2200T
+	1002  FLEXFLOW-2200T Ethernet Controller [Virtual Function]
+	1003  FLEXFLOW-2200T Ethernet Controller [MGMT Function]
 	1004  FLEXFLOW-2200T DATA Offload Engine
 	1011  FLEXFLOW-2200T Ethernet Controller
 		1f47 0001  Ethernet 10G 2P FLEXFLOW-2200T
@@ -28343,23 +28534,9 @@
 		1f47 0006  Ethernet 40G 2P CONFLUX-2200E
 		1f47 0007  Ethernet 100G 1P CONFLUX-2200E
 		1f47 0008  Ethernet 100G 2P CONFLUX-2200E
-		1f47 0009  Ethernet 25G 2P CONFLUX-2200E
-		1f47 000a  Ethernet 40G 2P CONFLUX-2200E
-		1f47 000b  Ethernet 100G 1P CONFLUX-2200E
-		1f47 000c  Ethernet 100G 2P CONFLUX-2200E
-	4011  CONFLUX-2200E Ethernet Controller
-		1f47 0001  Ethernet 25G 2P CONFLUX-2200E
-		1f47 0002  Ethernet 40G 2P CONFLUX-2200E
-		1f47 0003  Ethernet 100G 1P CONFLUX-2200E
-		1f47 0004  Ethernet 100G 2P CONFLUX-2200E
-		1f47 0005  Ethernet 25G 2P CONFLUX-2200E
-		1f47 0006  Ethernet 40G 2P CONFLUX-2200E
-		1f47 0007  Ethernet 100G 1P CONFLUX-2200E
-		1f47 0008  Ethernet 100G 2P CONFLUX-2200E
-		1f47 0009  Ethernet 25G 2P CONFLUX-2200E
-		1f47 000a  Ethernet 40G 2P CONFLUX-2200E
-		1f47 000b  Ethernet 100G 1P CONFLUX-2200E
-		1f47 000c  Ethernet 100G 2P CONFLUX-2200E
+	4002  CONFLUX-2200E Ethernet Controller [Virtual Function]
+	4003  CONFLUX-2200E Ethernet Controller [MGMT Function]
+	4004  CONFLUX-2200E DATA Offload Engine
 	5001  CONFLUX-2200P Ethernet Controller
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200P
 		1f47 0003  Ethernet 100G 2P CONFLUX-2200P
@@ -28369,6 +28546,7 @@
 		1f47 0009  Ethernet 100G 2P CONFLUX-2200P
 		1f47 000a  Ethernet 25G 2P CONFLUX-2200P
 		1f47 000c  Ethernet 100G 2P CONFLUX-2200P
+	5002  CONFLUX-2200P Ethernet Controller [Virtual Function]
 	5003  CONFLUX-2200P NVMe Controller
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200P
 		1f47 0003  Ethernet 100G 2P CONFLUX-2200P
@@ -28378,12 +28556,14 @@
 		1f47 0009  Ethernet 100G 2P CONFLUX-2200P
 		1f47 000a  Ethernet 25G 2P CONFLUX-2200P
 		1f47 000c  Ethernet 100G 2P CONFLUX-2200P
+	5004  CONFLUX-2200P NVMe Controller [Virtual Function]
 	5005  CONFLUX-2200P Ethernet Controller [MGMT Function]
 		1f47 0001  CONFLUX-2200P Ethernet Controller [MGMT Function]
 		1f47 0002  CONFLUX-2200P Ethernet Controller [MGMT Function] DPU
 	5006  CONFLUX-2200P Ethernet Controller [YDMI Function]
 		1f47 0001  CONFLUX-2200P Ethernet Controller [YDMI Function]
 		1f47 0002  CONFLUX-2200P Ethernet Controller [YDMI Function] DPU
+	5007  CONFLUX-2200P DATA OFFLOAD ENGINE
 	5011  CONFLUX-2200P Ethernet Controller
 		1f47 0004  Ethernet 25G 2P CONFLUX-2200P
 		1f47 0006  Ethernet 100G 2P CONFLUX-2200P
@@ -28562,6 +28742,7 @@
 		1fe4 0075  Enterprise NVMe SSD U.2 3.84TB(HP610)
 		1fe4 0076  Enterprise NVMe SSD U.2 7.68TB(HP610)
 		1fe4 0078  Enterprise NVMe SSD U.2 3.20TB(HP630)
+		1fe4 0079  Enterprise NVMe SSD U.2 6.40TB (HP630)
 1fe9  MemryX
 	0100  MX3
 # Linkdata Technology (Tianjin) Co., LTD
@@ -28607,8 +28788,10 @@
 		2036 0863  NF1618 Family NX863 (2*100GE)
 		2036 0864  NF1618 Family NX864 (1*200GE)
 	1619  NF1618 Family Virtual Function
+203b  XTX Markets Technologies Ltd.
 2046  GXMICRO Technology (Shanghai) Co., Ltd.
 2048  Beijing SpaceControl Technology Co.Ltd
+2058  Lime Microsystems Ltd.
 205c  Zhejiang VMing Semiconductor Co., Ltd.
 	1514  EP9410 U.2 1.92TB NVME SSD
 	1515  EP9410 U.2 3.84TB NVME SSD
@@ -28667,6 +28850,7 @@
 	5402  KCP54(02) 2280 PCIe G4 x4 TLC
 	5403  KCP54(03) 2280 PCIe G4 x4 TLC
 	5404  KCP54(04) 2280 PCIe G4 x4 TLC
+2099  Rolling Wireless S.a.r.l.
 209b  BitIntelligence Technology
 	1000  TCU Family - TCU-1
 	1001  TCU Family - TCU-1 Virtual Function
@@ -28683,8 +28867,11 @@
 	0111  OPNIC
 20bc  Xinsheng Technology Co., Ltd.
 	1001  Smart Network Adapter
+		20bc 1082  Ethernet Network Adapter XS-N1082-2X for 10GbE SFP+ Dual-port
 		20bc 2083  Ethernet Network Adapter XS-N2083-2X for 25GbE SFP28 SFP+ Dual-port ROCEv2
 	2001  Solid State Storage
+20d0  Telin Semiconductor (Wuhan) Co., Ltd.
+	1001  Pacific-S1 X2-07T6U2
 20f4  TRENDnet
 2116  ZyDAS Technology Corp.
 21b4  Hunan Goke Microelectronics Co., Ltd
@@ -28725,7 +28912,7 @@
 	501c  NV2 NVMe SSD [E19T] (DRAM-less)
 	501d  NV2 NVMe SSD [TC2200] (DRAM-less)
 	501e  OM3PGP4 NVMe SSD (DRAM-less)
-	501f  FURY Renegade NVMe SSD + Heatsink [E18]
+	501f  FURY Renegade NVMe SSD [E18] (Heatsink)
 	5021  OM8SEP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
 	5022  OM8PGP4 Design-In PCIe 4 NVMe SSD (QLC) (DRAM-less)
 	5023  NV2 NVMe SSD [SM2269XT] (DRAM-less)
@@ -31312,8 +31499,9 @@
 		8086 0001  Ethernet Network Adapter E830-XXV-2 for OCP 3.0
 		8086 0003  Ethernet Network Adapter E830-XXV-2
 		8086 0004  Ethernet Network Adapter E830-XXV-4 for OCP 3.0
-		8086 0005  Ethernet Network Adapter E830-XXV-8 for OCP 3.0
-		8086 0006  Ethernet Network Adapter E830-XXV-8
+		8086 0005  Ethernet Network Adapter E830-XXV-8F for OCP 3.0
+		8086 0006  Ethernet Network Adapter E830-XXV-8F
+		8086 0007  Ethernet Network Adapter E830-XXV-4F
 	12d4  Ethernet Controller E830-CC for SFP-DD
 	12d5  Ethernet Controller E830-C for backplane
 	12d8  Ethernet Controller E830-C for QSFP
@@ -34700,6 +34888,7 @@
 		17aa 20a6  ThinkPad T61/R61
 		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 		e4bf cc47  CCG-RUMBA
+	2880  Ice Lake DDRIO Registers
 	28c0  Volume Management Device NVMe RAID Controller
 	2912  82801IH (ICH9DH) LPC Interface Controller
 	2914  82801IO (ICH9DO) LPC Interface Controller
@@ -35689,7 +35878,33 @@
 	3438  7500/5520/5500/X58 I/O Hub Throttle Registers
 	3440  Ice Lake UPI Misc
 	3441  Ice Lake UPI Link/Phy0
+	3442  Ice Lake UPI Phy0 Registers
+	3445  Ice Lake UPI Mesh Stop Registers
+	3446  Ice Lake UPI PMON0 Registers
+	3447  Ice Lake UPI PMON1 Registers
+	3448  Ice Lake PCU Registers
+	344a  Ice Lake Integrated Memory Controller
+	344b  Ice Lake PCU Registers
+	344c  Ice Lake CHA Registers
+	344d  Ice Lake CHA Registers
+	344f  Ice Lake CHA Registers
+	3450  Ice Lake Ubox Registers
+	3451  Ice Lake Ubox Registers
+	3452  Ice Lake Ubox Registers
+	3455  Ice Lake Ubox Registers
 	3456  Ice Lake NorthPeak
+	3457  Ice Lake CHA Registers
+	3458  Ice Lake PCU Registers
+	3459  Ice Lake PCU Registers
+	345a  Ice Lake PCU Registers
+	345b  Ice Lake PCU Registers
+	345c  Ice Lake PCU Registers
+	345d  Ice Lake PCU Registers
+	345e  Ice Lake PCU Registers
+	347a  Ice Lake PCI Express Root Port A
+	347b  Ice Lake PCI Express Root Port B
+	347c  Ice Lake PCI Express Root Port C
+	347d  Ice Lake PCI Express Root Port D
 	347e  Ice Lake Xeon Non-Transparent Bridge
 	3482  Ice Lake-LP LPC Controller
 	34a3  Ice Lake-LP SMBus Controller
@@ -36879,21 +37094,21 @@
 	56c0  ATS-M [Data Center GPU Flex 170]
 	56c1  ATS-M [Data Center GPU Flex 140]
 	56c2  ATS-M [Data Center GPU Flex 170V]
-	5780  Thunderbolt 80/120G Bridge [Barlow Ridge Host 80G 2023]
-	5781  Thunderbolt 80/120G NHI [Barlow Ridge Host 80G 2023]
-	5782  Thunderbolt 80/120G USB Controller [Barlow Ridge Host 80G 2023]
-	5783  Thunderbolt Bridge [Barlow Ridge Host 40G 2023]
-	5784  Thunderbolt NHI [Barlow Ridge Host 40G 2023]
-	5785  Thunderbolt USB Controller [Barlow Ridge Host 40G 2023]
-	5786  Thunderbolt 80/120G Bridge [Barlow Ridge Hub 80G 2023]
-	5787  Thunderbolt 80/120G USB Controller [Barlow Ridge Hub 80G 2023]
+	5780  JHL9580 Thunderbolt 5 80/120G Bridge [Barlow Ridge Host 80G 2023]
+	5781  JHL9580 Thunderbolt 5 80/120G NHI [Barlow Ridge Host 80G 2023]
+	5782  JHL9580 Thunderbolt 5 80/120G USB Controller [Barlow Ridge Host 80G 2023]
+	5783  JHL9540 Thunderbolt 4 Bridge [Barlow Ridge Host 40G 2023]
+	5784  JHL9540 Thunderbolt 4 NHI [Barlow Ridge Host 40G 2023]
+	5785  JHL9540 Thunderbolt 4 USB Controller [Barlow Ridge Host 40G 2023]
+	5786  JHL9480 Thunderbolt 5 80/120G Bridge [Barlow Ridge Hub 80G 2023]
+	5787  JHL9480 Thunderbolt 5 80/120G USB Controller [Barlow Ridge Hub 80G 2023]
 	5795  Granite Rapids Chipset LPC Controller
 	579c  Ethernet Connection E825-C for backplane
 	579d  Ethernet Connection E825-C for QSFP
 	579e  Ethernet Connection E825-C for SFP
 	579f  Ethernet Connection E825-C 10GbE
-	57a4  Thunderbolt Bridge [Barlow Ridge Hub 40G 2023]
-	57a5  Thunderbolt USB Controller [Barlow Ridge Hub 40G 2023]
+	57a4  JHL9440 Thunderbolt 4 Bridge [Barlow Ridge Hub 40G 2023]
+	57a5  JHL9440 Thunderbolt 4 USB Controller [Barlow Ridge Hub 40G 2023]
 	57ad  E610 Virtual Function
 	57ae  Ethernet Controller E610 Backplane
 	57af  Ethernet Controller E610 SFP
@@ -37351,6 +37566,7 @@
 	7af8  Alder Lake-S Integrated Sensor Hub
 	7afc  Alder Lake-S PCH Serial IO I2C Controller #4
 	7afd  Alder Lake-S PCH Serial IO I2C Controller #5
+	7d01  Meteor Lake-H 6p+8e cores Host Bridge/DRAM Controller
 	7d03  Meteor Lake-P Dynamic Tuning Technology
 	7d0b  Volume Management Device NVMe RAID Controller Intel Corporation
 	7d0d  Meteor Lake-P Platform Monitoring Technology
@@ -37366,6 +37582,7 @@
 	7dd1  Arrow Lake-P [Intel Graphics]
 	7dd5  Meteor Lake-P [Intel Graphics]
 	7e01  Meteor Lake-P LPC/eSPI Controller
+	7e02  Meteor Lake-H eSPI Controller
 	7e22  Meteor Lake-P SMBus Controller
 	7e23  Meteor Lake-P SPI Controller
 	7e24  Meteor Lake-P Trace Hub
@@ -37374,12 +37591,14 @@
 	7e27  Meteor Lake-P Serial IO SPI Controller #0
 	7e28  Meteor Lake-P HD Audio Controller
 	7e30  Meteor Lake-P Serial IO SPI Controller #1
+	7e3f  Meteor Lake-H/U PCIe Root Port #8
 	7e40  Meteor Lake PCH CNVi WiFi
 		8086 0094  Wi-Fi 6E AX211 160MHz
 # Refer from Intel Meteor Lake EDS (doc#640228) under its "Device IDs" section.
 	7e45  Meteor Lake-P Integrated Sensor Hub
 	7e46  Meteor Lake-P Serial IO SPI Controller #2
 	7e4c  Meteor Lake-P Gaussian & Neural-Network Accelerator
+	7e4d  Meteor Lake-H/U PCIe Root Port #9
 	7e50  Meteor Lake-P Serial IO I2C Controller #4
 	7e51  Meteor Lake-P Serial IO I2C Controller #5
 	7e52  Meteor Lake-P Serial IO UART Controller #2
@@ -37391,6 +37610,7 @@
 	7e7b  Meteor Lake-P Serial IO I2C Controller #3
 	7e7d  Meteor Lake-P USB 3.2 Gen 2x1 xHCI Host Controller
 	7e7e  Meteor Lake-P USB Device Controller
+	7e7f  Meteor Lake-H/U Shared SRAM
 	7ec0  Meteor Lake-P Thunderbolt 4 USB Controller
 	7ec2  Meteor Lake-P Thunderbolt 4 NHI #0
 	7ec3  Meteor Lake-P Thunderbolt 4 NHI #1
@@ -37398,6 +37618,8 @@
 	7ec5  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1
 	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
 	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
+	7eca  Meteor Lake-H/U PCIe Root Port #10
+	7ecc  Meteor Lake-H PCIe Root Port #12
 	7f70  Arrow Lake-S PCH CNVi WiFi
 		8086 0094  WiFi 6E AX211 160MHz
 	8002  Trusted Execution Technology Registers
@@ -38320,7 +38542,7 @@
 	a1ea  C620 Series Chipset Family PCI Express Root Port #20
 	a1ec  C620 Series Chipset Family MROM 0
 	a1ed  C620 Series Chipset Family MROM 1
-	a1f0  Lewisburg MROM 0
+	a1f0  C62x HD Audio Controller
 	a1f8  Lewisburg IE: HECI #1
 	a1f9  Lewisburg IE: HECI #2
 	a1fa  Lewisburg IE: IDE-r
@@ -38328,12 +38550,33 @@
 	a1fc  Lewisburg IE: HECI #3
 	a202  Lewisburg SATA Controller [AHCI mode]
 	a206  Lewisburg SATA Controller [RAID mode]
+	a210  Lewisburg PCI Express Root Port
+	a211  Lewisburg PCI Express Root Port
+	a212  Lewisburg PCI Express Root Port
+	a213  Lewisburg PCI Express Root Port
+	a214  Lewisburg PCI Express Root Port
+	a215  Lewisburg PCI Express Root Port
+	a216  Lewisburg PCI Express Root Port
+	a217  Lewisburg PCI Express Root Port
+	a218  Lewisburg PCI Express Root Port
+	a219  Lewisburg PCI Express Root Port
+	a21a  Lewisburg PCI Express Root Port
+	a21b  Lewisburg PCI Express Root Port
+	a21c  Lewisburg PCI Express Root Port
+	a21d  Lewisburg PCI Express Root Port
+	a21e  Lewisburg PCI Express Root Port
+	a21f  Lewisburg PCI Express Root Port
+	a221  Lewisburg Power Management Controller
 	a223  Lewisburg SMBus
 	a224  Lewisburg SPI Controller
 	a242  Lewisburg LPC or eSPI Controller
 	a243  Lewisburg LPC or eSPI Controller
 	a252  Lewisburg SSATA Controller [AHCI mode]
 	a256  Lewisburg SSATA Controller [RAID mode]
+	a267  Lewisburg PCI Express Root Port
+	a268  Lewisburg PCI Express Root Port
+	a269  Lewisburg PCI Express Root Port
+	a26a  Lewisburg PCI Express Root Port
 	a282  200 Series PCH SATA controller [AHCI mode]
 		1462 7a72  H270 PC MATE
 	a286  200 Series PCH SATA controller [RAID mode]
@@ -38568,6 +38811,10 @@
 	b081  Panther Lake [Intel Graphics]
 	b082  Panther Lake [Intel Graphics]
 	b083  Panther Lake [Intel Graphics]
+	b084  Panther Lake [Intel Graphics]
+	b085  Panther Lake [Intel Graphics]
+	b086  Panther Lake [Intel Graphics]
+	b087  Panther Lake [Intel Graphics]
 	b08f  Panther Lake [Intel Graphics]
 	b090  Panther Lake [Intel Graphics]
 	b0a0  Panther Lake [Intel Graphics]
@@ -38618,10 +38865,10 @@
 	e212  Battlemage G21 [Intel Graphics]
 	e215  Battlemage G21 [Intel Graphics]
 	e216  Battlemage G21 [Intel Graphics]
-	e220  Battlemage G21 [Intel Graphics]
-	e221  Battlemage G21 [Intel Graphics]
-	e222  Battlemage G21 [Intel Graphics]
-	e223  Battlemage G21 [Intel Graphics]
+	e220  Battlemage G31 [Intel Graphics]
+	e221  Battlemage G31 [Intel Graphics]
+	e222  Battlemage G31 [Intel Graphics]
+	e223  Battlemage G31 [Intel Graphics]
 	f1a5  SSD 600P Series
 		8086 390a  SSDPEKKW256G7 256GB
 	f1a6  SSD DC P4101/Pro 7600p/760p/E 6100p Series
@@ -38630,6 +38877,8 @@
 	f1a8  SSD 660P Series
 	f1aa  SSD 670p Series [Keystone Harbor]
 	faf0  SSD 665p Series [Neptune Harbor Refresh]
+	fd80  Wildcat Lake [Intel Graphics]
+	fd81  Wildcat Lake [Intel Graphics]
 8088  Beijing Wangxun Technology Co., Ltd.
 	0100  WX1860AL-W Gigabit Ethernet Controller
 	0101  WX1860A2 Gigabit Ethernet Controller
@@ -38770,8 +39019,8 @@
 		4c52 3043  LRES3043PT Dual-port 1Gb Ethernet Server Adapter for OCP
 8866  T-Square Design Inc.
 8888  Silicon Magic
-# 4 port HDMI capture card
-	8504  AVMatrix VC42
+	8504  AVMatrix VC42 4-port HDMI Capture
+	8581  AVMatrix VC12 4K HDMI Capture
 8912  TRX
 # 8c4a is not Winbond but there is a board misprogrammed
 8c4a  Winbond
@@ -39554,6 +39803,8 @@ d20c  Chengdu BeiZhongWangXin Technology Co., Ltd.
 		d20c e421  N6S Series 2-port 40GbE Network Adapter
 		d20c ea21  N6S Series 2-port 100GbE Network Adapter
 d405  LeapIO
+	8200  LeapSAS
+	8201  LeapRAID
 d4d4  Dy4 Systems Inc
 	0601  PCI Mezzanine Card
 d531  I+ME ACTIA GmbH


### PR DESCRIPTION
## Summary by Sourcery

Bump hwdata to version 0.397 and refresh hardware identification data

Enhancements:
- Update pci.ids, iab.txt, and oui.txt with the latest PCI and vendor identifiers

Build:
- Increment spec version to 0.397 and add corresponding changelog entry