### PR TITLE
Sep update

### DIFF
--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.398
+Version: 0.399
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Mon Sep 01 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.399-1
+- Update vendor ids
+
 * Fri Aug 01 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.398-1
 - Update pci, usb and vendor ids
 

--- a/iab.txt
+++ b/iab.txt
@@ -17192,12 +17192,6 @@ F58000-F58FFF                 (base 16)                     IEEE Registration Au
                                                             Houston  TX  77042
                                                             US
 
-40-D8-55                      (hex)                         GeneSys Elektronik GmbH
-0EF000-0EFFFF                 (base 16)                     GeneSys Elektronik GmbH
-                                                            In der Spoeck 10
-                                                            77656 Offenburg
-                                                            US
-
 40-D8-55                      (hex)                         YUKO ELECTRIC CO.,LTD
 0D9000-0D9FFF                 (base 16)                     YUKO ELECTRIC CO.,LTD
                                                             ICHIGAYA BUILDING 2002-12
@@ -21559,6 +21553,12 @@ F08000-F08FFF                 (base 16)                     Aplex Technology Inc
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
+
+40-D8-55                      (hex)                         GeneSys Elektronik GmbH
+0EF000-0EFFFF                 (base 16)                     GeneSys Elektronik GmbH
+                                                            Maria-und-Georg-Dietrich-Str. 6
+                                                            Offenburg    77652
+                                                            DE
 
 00-50-C2                      (hex)                         RF Code
 1A6000-1A6FFF                 (base 16)                     RF Code


### PR DESCRIPTION
Update vendor ids

## Summary by Sourcery

Bump hwdata package to version 0.399 and refresh its vendor IDs

Enhancements:
- Update vendor IDs in the hardware identification data

Build:
- Bump package version to 0.399 in the spec file and add corresponding changelog entry