### PR TITLE
Fix check-usb-ids

### DIFF
--- a/check-usb-ids.sh
+++ b/check-usb-ids.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -10,7 +10,7 @@ fi
 
 tmpdir=`mktemp -d`
 echo "Listing usb devices:"
-sudo podman run -t --privileged --rm=true \
+podman run -t --privileged --rm=true \
     -v `pwd`/usb.ids:/usr/share/hwdata/usb.ids:ro \
     -v "$tmpdir:/mnt/out" \
     vcrhonek/hwdata-check \


### PR DESCRIPTION
Use /bin/sh for better portability. Drop unnecessary use of elevated priledges for podman.

Fixes https://github.com/vcrhonek/hwdata/issues/6

## Summary by Sourcery

Switch the shell to /bin/sh for better portability and remove the sudo wrapper on the podman run command to eliminate unnecessary elevated privileges.

Bug Fixes:
- Change shebang from /bin/bash to /bin/sh for improved portability
- Drop sudo from the podman run invocation to avoid requiring elevated privileges