### PR TITLE
Oct update

### DIFF
--- a/01-utf-8-encoding.patch.patch
+++ b/01-utf-8-encoding.patch.patch
@@ -1,6 +1,6 @@
---- usb.ids.converted	2025-08-01 09:57:10.118057102 +0200
-+++ usb.ids.updated	2025-08-01 09:57:10.122057073 +0200
-@@ -24531,7 +24531,7 @@
+--- usb.ids.converted	2025-10-02 08:56:41.322770441 +0200
++++ usb.ids.updated	2025-10-02 08:56:41.326770423 +0200
+@@ -24538,7 +24538,7 @@
  	031  \ and | (Backslash and Bar)
  	032  # and ~ (Hash and Tilde, Non-US Keyboard near right shift)
  	033  ; and : (Semicolon and Colon)

--- a/02-typos.patch.patch
+++ b/02-typos.patch.patch
@@ -1,6 +1,6 @@
---- usb.ids.orig	2025-08-01 10:01:36.262130524 +0200
-+++ usb.ids	2025-08-01 10:01:36.270130465 +0200
-@@ -24138,7 +24138,7 @@
+--- usb.ids.orig	2025-10-02 09:00:01.055818657 +0200
++++ usb.ids	2025-10-02 09:00:01.060818633 +0200
+@@ -24145,7 +24145,7 @@
  AT 0201  Microphone
  AT 0202  Desktop Microphone
  AT 0203  Personal Microphone
@@ -9,7 +9,7 @@
  AT 0205  Microphone Array
  AT 0206  Processing Microphone Array
  AT 0300  Output Undefined
-@@ -24153,8 +24153,8 @@
+@@ -24160,8 +24160,8 @@
  AT 0401  Handset
  AT 0402  Headset
  AT 0403  Speakerphone, no echo reduction
@@ -20,7 +20,7 @@
  AT 0500  Telephony Undefined
  AT 0501  Phone line
  AT 0502  Telephone
-@@ -24376,7 +24376,7 @@
+@@ -24383,7 +24383,7 @@
  	0b9  Elevator Trim
  	0ba  Rudder
  	0bb  Throttle
@@ -29,7 +29,7 @@
  	0bd  Flare Release
  	0be  Landing Gear
  	0bf  Toe Break
-@@ -24393,8 +24393,8 @@
+@@ -24400,8 +24400,8 @@
  	0ca  Barrel Elevation
  	0cb  Drive Plane
  	0cc  Ballast
@@ -40,7 +40,7 @@
  	0cf  Front Brake
  	0d0  Rear Brake
  HUT 03  VR Controls
-@@ -24666,7 +24666,7 @@
+@@ -24673,7 +24673,7 @@
  	00b  High Cut Filter
  	00c  Low Cut Filter
  	00d  Equalizer Enable
@@ -49,7 +49,7 @@
  	00f  Surround On
  	010  Repeat
  	011  Stereo
-@@ -25209,7 +25209,7 @@
+@@ -25216,7 +25216,7 @@
  	02d  Display Status
  	02e  Stat Not Ready
  	02f  Stat Ready
@@ -58,7 +58,7 @@
  	031  Err Font Data Cannot Be Read
  	032  Cursur Position Report
  	033  Row
-@@ -25477,14 +25477,14 @@
+@@ -25484,14 +25484,14 @@
  	04  Libya
  	05  Algeria
  	06  Morocco
@@ -75,7 +75,7 @@
  	0f  Bahrain
  	10  Qatar
  L 0002  Bulgarian
-@@ -25513,7 +25513,7 @@
+@@ -25520,7 +25520,7 @@
  	06  Ireland
  	07  South Africa
  	08  Jamaica
@@ -84,7 +84,7 @@
  	0a  Belize
  	0b  Trinidad
  	0c  Zimbabwe
-@@ -25549,7 +25549,7 @@
+@@ -25556,7 +25556,7 @@
  	06  Monaco
  L 000d  Hebrew
  L 000e  Hungarian
@@ -93,7 +93,7 @@
  L 0010  Italian
  	01  Italian
  	02  Swiss
-@@ -25603,13 +25603,13 @@
+@@ -25610,13 +25610,13 @@
  L 002f  Macedonian
  L 0036  Afrikaans
  L 0037  Georgian

--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.399
+Version: 0.400
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Oct 02 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.400-1
+- Update usb and vendor ids
+
 * Mon Sep 01 2025 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.399-1
 - Update vendor ids
 

--- a/iab.txt
+++ b/iab.txt
@@ -15845,12 +15845,6 @@ A1A000-A1AFFF                 (base 16)                     DDL
 00-50-C2                      (hex)                         Private
 064000-064FFF                 (base 16)                     Private
 
-00-50-C2                      (hex)                         PMC
-16E000-16EFFF                 (base 16)                     PMC
-                                                            56, Avenue Raspail
-                                                            Saint Maur
-                                                            FR
-
 00-50-C2                      (hex)                         Private
 062000-062FFF                 (base 16)                     Private
 
@@ -16303,6 +16297,12 @@ B49000-B49FFF                 (base 16)                     Aplex Technology Inc
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
+
+00-50-C2                      (hex)                         Groupe Carrus
+16E000-16EFFF                 (base 16)                     Groupe Carrus
+                                                            56, Avenue Raspail
+                                                            Saint Maur
+                                                            FR
 
 00-50-C2                      (hex)                         Timberline Manufacturing
 B5B000-B5BFFF                 (base 16)                     Timberline Manufacturing

--- a/usb.ids
+++ b/usb.ids
@@ -9,8 +9,8 @@
 #	The latest version can be obtained from
 #		http://www.linux-usb.org/usb.ids
 #
-# Version: 2025.07.26
-# Date:    2025-07-26 20:34:01
+# Version: 2025.09.15
+# Date:    2025-09-15 20:34:02
 #
 
 # Vendors, devices and interfaces. Please keep sorted.
@@ -13488,7 +13488,9 @@
 0b0d  ProjectLab
 	0000  CenturyCD
 0b0e  GN Netcom
+	0301  Jabra EVOLVE 20
 	0305  Jabra EVOLVE Link MS
+	030c  Jabra EVOLVE 65
 	0311  Jabra EVOLVE 65
 	0312  enc060:Buttons Volume up/down/mute + phone [Jabra]
 	0343  Jabra UC VOICE 150a
@@ -13507,6 +13509,11 @@
 	2007  GN 2000 Stereo Corded Headset
 	2456  Jabra SPEAK 810
 	245e  Jabra Link 370
+	248a  Jabra Elite 85h
+	24b8  Jabra Evolve2 65
+	24bb  Jabra Evolve2 85
+	24c9  Jabra Link 380
+	24ca  Jabra Link 380
 	620c  Jabra BT620s
 	9330  Jabra GN9330 Headset
 	a346  Jabra Engage 75 Stereo


### PR DESCRIPTION
## Summary by Sourcery

Bump hwdata to version 0.400 and update USB and vendor identification data.

Enhancements:
- Update package version from 0.399 to 0.400
- Refresh USB and vendor IDs data