### PR TITLE
Feb update

### DIFF
--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.403
+Version: 0.404
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Feb 05 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.404-1
+- Update pci and vendor ids
+
 * Fri Jan 02 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.403-1
 - Update pci, usb and vendor ids
 

--- a/iab.txt
+++ b/iab.txt
@@ -10541,12 +10541,6 @@ DAF000-DAFFFF                 (base 16)                     eumig industrie-TV G
                                                             Milton Keynes  Buckinghamshire  MK5 6LB
                                                             GB
 
-00-50-C2                      (hex)                         Aplex Technology Inc.
-DAB000-DABFFF                 (base 16)                     Aplex Technology Inc.
-                                                            15F-1, No.186, Jian Yi Road
-                                                            Zhonghe District  New Taipei City 235   -
-                                                            TW
-
 40-D8-55                      (hex)                         Aplex Technology Inc.
 00C000-00CFFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
@@ -10561,6 +10555,12 @@ E6A000-E6AFFF                 (base 16)                     Aplex Technology Inc
 
 00-50-C2                      (hex)                         Aplex Technology Inc.
 E00000-E00FFF                 (base 16)                     Aplex Technology Inc.
+                                                            15F-1, No.186, Jian Yi Road
+                                                            Zhonghe District  New Taipei City 235   -
+                                                            TW
+
+00-50-C2                      (hex)                         Aplex Technology Inc.
+DAB000-DABFFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
@@ -16286,14 +16286,14 @@ F16000-F16FFF                 (base 16)                     Peter Huber Kaeltema
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
 
-40-D8-55                      (hex)                         Aplex Technology Inc.
-18A000-18AFFF                 (base 16)                     Aplex Technology Inc.
+00-50-C2                      (hex)                         Aplex Technology Inc.
+B49000-B49FFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
 
-00-50-C2                      (hex)                         Aplex Technology Inc.
-B49000-B49FFF                 (base 16)                     Aplex Technology Inc.
+40-D8-55                      (hex)                         Aplex Technology Inc.
+18A000-18AFFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
@@ -21536,14 +21536,14 @@ DBA000-DBAFFF                 (base 16)                     Motor Protection Ele
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
 
-40-D8-55                      (hex)                         Aplex Technology Inc.
-060000-060FFF                 (base 16)                     Aplex Technology Inc.
+00-50-C2                      (hex)                         Aplex Technology Inc.
+F08000-F08FFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
 
-00-50-C2                      (hex)                         Aplex Technology Inc.
-F08000-F08FFF                 (base 16)                     Aplex Technology Inc.
+40-D8-55                      (hex)                         Aplex Technology Inc.
+060000-060FFF                 (base 16)                     Aplex Technology Inc.
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW

--- a/pci.ids
+++ b/pci.ids
@@ -1,8 +1,8 @@
 #
 #	List of PCI IDs
 #
-#	Version: 2026.01.02
-#	Date:    2026-01-02 03:15:02
+#	Version: 2026.02.04
+#	Date:    2026-02-04 03:15:02
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -830,6 +830,7 @@
 		15d9 1d08  AOC-S4016L-L16IR Storage Adapter
 		17aa 7855  ThinkSystem RAID 950W-16i 8GB Flash PCIe Gen4 24Gb Adapter
 		1d49 020a  ThinkSystem 450W-16e SAS/SATA PCIe Gen4 24Gb HBA
+		1d49 020c  ThinkSystem 450W-16e PCIe Gen4 HBA
 	00ab  SAS3516 Fusion-MPT Tri-Mode RAID On Chip (ROC)
 # 8 Internal and 8 External port channel 9400 HBA
 		1000 3040  HBA 9400-8i8e
@@ -4018,6 +4019,7 @@
 		1002 0b36  Reference RX 5700 XT
 		1458 2313  Radeon RX 5700 XT Gaming OC
 		1458 231d  Radeon RX 5600 XT/REV 2.0 [Windforce 6GB OC]
+		1462 381e  RX 5600 XT MECH OC
 		148c 2398  AXRX 5700 XT 8GBD6-3DHE/OC [PowerColor Red Devil Radeon RX 5700 XT]
 		1682 5701  RX 5700 XT RAW II
 		1849 5102  RX5700 CLD 8GO [ASRock Challenger D RX 5700 OC]
@@ -4025,8 +4027,9 @@
 		1da2 e409  Sapphire Technology Limited Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
 		1da2 e410  Sapphire NITRO+ RX 5700 XT
 		1da2 e411  Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
-	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5500M]
+	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5300/5500M]
 		106b 0210  Radeon Pro 5300M
+		106b 0219  iMac (Retina 5K, 27-inch, 2020) [Radeon Pro 5300]
 	7341  Navi 14 [Radeon Pro W5500]
 	7347  Navi 14 [Radeon Pro W5500M]
 	734f  Navi 14 [Radeon Pro W5300M]
@@ -4144,6 +4147,7 @@
 		1da2 e490  Navi 48 XTX [Sapphire Pulse Radeon RX 9070 XT]
 	7551  Navi 48 [Radeon AI PRO R9700]
 	7590  Navi 44 [Radeon RX 9060 XT]
+		1458 2429  GV-R9060XTGAMING OC-16GD [Radeon RX 9060 XT GAMING OC 16G]
 		1eae 8601  RX-96TS316W7 [SWIFT RX 9060 XT OC White Triple Fan Gaming Edition 16GB]
 	75a0  Aqua Vanjaram [Instinct MI350X]
 	75a3  Aqua Vanjaram [Instinct MI355X]
@@ -20737,10 +20741,6 @@
 	f436  AVerTV Hybrid+FM
 1462  Micro-Star International Co., Ltd. [MSI]
 	3483  MSI USB 3.0 (VIA VL80x-based xHCI USB Controller)
-# This is MSI refreshed variant of their MECH series Navi 23 GPU card (73EF)
-	5027  RX 6650XT MECH 2X
-	7c56  Realtek Ethernet controller RTL8111H
-	aaf0  Radeon RX 580 Gaming X 8G
 1463  Fast Corporation
 1464  Interactive Circuits & Systems Ltd
 1465  GN NETTEST Telecom DIV.
@@ -22022,6 +22022,8 @@
 		0e11 0042  Yogi
 # Integrated in CX86111/CX86113 processors
 	1830  CX861xx Integrated Host Bridge
+	1f86  DBH CX11880 Codec
+	1f87  SMIC CX11880 Codec
 	2003  HSF 56k Data/Fax Modem
 	2004  HSF 56k Data/Fax/Voice Modem
 	2005  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
@@ -22656,11 +22658,11 @@
 	0274  Spectrum-6 in Flash Recovery Mode
 	0275  Spectrum-6 RMA
 	0277  Spectrum-6 Tile
-	0278  Nvlink-6 Switch in Flash Recovery Mode
-	0279  Nvlink-6 Switch RMA
+	0278  NVLink-6 Switch in Flash Recovery Mode
+	0279  NVLink-6 Switch RMA
 	027a  Eros Chiplet
-	027c  Nvlink-7 Switch in Flash Recovery Mode
-	027d  Nvlink-7 Switch RMA
+	027c  NVLink-7 Switch in Flash Recovery Mode
+	027d  NVLink-7 Switch RMA
 	027e  Spectrum-7 Tile
 	0281  NPS-600 Flash Recovery
 	0282  ArcusE Flash recovery
@@ -22684,8 +22686,8 @@
 	029a  OPHY3.1
 # Sagitta
 	029c  OPHY3.5
-	02a0  Nvlink-8 Switch in Flash Recovery Mode
-	02a1  Nvlink-8 RMA
+	02a0  NVLink-8 Switch in Flash Recovery Mode
+	02a1  NVLink-8 Switch RMA
 	02a2  Spectrum-7 in Flash Recovery Mode
 	02a3  Spectrum-7 RMA
 	1002  MT25400 Family [ConnectX-2 Virtual Function]
@@ -22808,6 +22810,7 @@
 	1024  CX8 PCIe Switch Family [ConnectX-8 PCIe Switch]
 	1025  CX9 Family [ConnectX-9]
 	1027  CX10 Family [ConnectX-10]
+	1028  CX10 Family [ConnectX-10 Trusted Network Control Memory]
 	1974  MT28800 Family [ConnectX-5 PCIe Bridge]
 	1975  MT416842 Family [BlueField SoC PCIe Bridge]
 	1976  MT28908 Family [ConnectX-6 PCIe Bridge]
@@ -22826,6 +22829,8 @@
 	2024  MT43244 Family [BlueField-3 SoC Emulated PCIe Bridge]
 	2025  ConnectX/BlueField Family mlx5Gen Emulated PCIe Bridge [Emulated PCIe Bridge]
 	2100  CX8 Family [CX8 Data Direct Interface]
+# Chip to Chip Link
+	2101  CX10 Family [ConnectX-10 C2C]
 	4117  MT27712A0-FDCF-AE
 		1bd4 0039  SN10XMP2P25
 		1bd4 003a  25G SFP28 SP EO251FM9 Adapter
@@ -22919,9 +22924,9 @@
 	d2f2  Quantum-2 NDR (400Gbps) switch
 	d2f4  Quantum-3
 	d2f6  Quantum-3CPO
-	d2f8  Nvlink-6 Switch
-	d2fa  Nvlink-7 Switch
-	d2fc  Nvlink-8 Switch
+	d2f8  NVLink-6 Switch
+	d2fa  NVLink-7 Switch
+	d2fc  NVLink-8 Switch
 15b4  CCI/TRIAD
 15b5  Cimetrics Inc
 15b6  Texas Memory Systems Inc
@@ -23307,9 +23312,14 @@
 # nee Atheros Communications, Inc.
 168c  Qualcomm Atheros
 	0007  AR5210 Wireless Network Adapter [AR5000 802.11a]
+		1186 3a00  DWL-A650 5GHz Wireless CardBus Adapter
+		1186 3a02  DWL-A520 5GHz Wireless PCI Adapter
+		1668 0429  802CA Wireless PC Card
 		1737 0007  WPC54A Wireless PC Card
 		1b47 0100  Harmony 8450CN Wireless CardBus Module
 		1b47 0110  Skyline 4030 / Harmony 8450 802.11a Wireless CardBus Adapter
+		1b47 0400  PC50E-8-FC/A Wireless Access Point Radio Card
+		8086 2500  PRO/Wireless 5000 LAN CardBus Adapter
 		8086 2501  PRO/Wireless 5000 LAN PCI Adapter Module
 	0011  AR5211 Wireless Network Adapter [AR5001A 802.11a]
 	0012  AR5211 Wireless Network Adapter [AR5001X 802.11ab]
@@ -23804,6 +23814,7 @@
 	7174  VSC7174 PCI/PCI-X Serial ATA Host Bus Controller
 172a  Accelerated Encryption
 	13c8  AEP SureWare Runner 1000V3
+172f  Sparkle Computer Co., Ltd.
 # nee Fujitsu Siemens Computers GmbH
 1734  Fujitsu Technology Solutions
 	1228  iRMC-S5 HTI Device
@@ -24500,6 +24511,7 @@
 	08b0  MVC200-DC
 1846  Alcatel-Lucent
 1849  ASRock Incorporation
+	1150  ASPEED AST1150 PCI-to-PCI Bridge
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 184a  Thales Computers
 	1100  MAX II cPLD
@@ -25165,6 +25177,8 @@
 1993  Innominate Security Technologies AG
 1998  Toyou Feiji Electronics Co., Ltd.
 	0001  TOBOLT1 51987 NVMe SSD
+		1998 0384  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
+		1998 0768  TOBOLT1 51987 7680G 2.5" U.2 NVMe SSD
 		1998 2012  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
 1999  A-Logics
 	a900  AM-7209 Video Processor
@@ -25380,7 +25394,7 @@
 		15d9 086b  X10DRS (AST2400 BMC)
 		15d9 1b95  H12SSL-i (AST2500 BMC)
 		15d9 1d50  X14DBG-AP (AST2600 BMC)
-		1849 2000  ROME2D32LM3 (AST2500 BMC)
+		1849 2000  Onboard Graphics
 1a05  deltaww
 1a07  Kvaser AB
 	0006  CAN interface PC104+ HS/HS
@@ -26162,7 +26176,9 @@
 # Nytro 5060H (Rocinante High Performance) non-SED
 		1bb1 0181  Nytro 5060H
 		1bb1 01a1  Nytro XP7102
+	0153  Nytro 5x50 NVMe SSD
 	0155  Nytro 5x50 NVMe SSD
+	2000  PCIe Gen4 SSD
 	5012  FireCuda/IronWolf 510 SSD
 	5013  BarraCuda Q5 NVMe SSD (DRAM-less)
 	5016  FireCuda 520/IronWolf 525 SSD
@@ -26272,6 +26288,8 @@
 	3252  CH382 PCIe Dual Port Serial Adapter
 # Device ID reused: CH352 is for PCI bus, CH382 for PCIe.
 	3253  CH352/CH382 PCI/PCIe Dual Port Serial Adapter
+	3470  CH384 Serial Adapter, 4-port mode
+	3853  CH384 Serial Adapter, 8-port mode
 1c09  CSP, Inc.
 	4254  10G-PCIE3-8D-2S
 	4255  10G-PCIE3-8D-Q
@@ -26628,7 +26646,7 @@
 	1602  LEGEND 900 NVMe SSD (DRAM-less)
 # SX6000LNP
 	2263  XPG SX6000 Lite NVMe SSD (DRAM-less)
-	2708  Premier Extreme microSDXC SD7.1 Express Card (DRAM-less)
+	2708  Premier Extreme SDXC SD 7.0 / microSDXC SD 7.1 Express Card (DRAM-less)
 	32a8  SM2P32A8 NVMe SSD (DRAM-less)
 	33f3  IM2P33F3 NVMe SSD (DRAM-less)
 	33f4  IM2P33F4 NVMe SSD (DRAM-less)
@@ -26690,6 +26708,12 @@
 	5201  AM520 PCIe 3.0 NVMe SSD 128GB
 	5212  AM521 PCIe 3.0 NVMe SSD 256GB
 	5414  AM541 PCIe 4.0 NVMe SSD 1024GB
+	6020  NVMe SSD Controller UM3X1X series
+		1cc4 8320  NVMe SSD UM301a M.2 480GB
+		1cc4 8321  NVMe SSD UM301a M.2 960GB
+		1cc4 8322  NVMe SSD UM301a M.2 1.92TB
+		1ea0 8320  NVMe SSD TM1300 M.2 480GB
+		1ea0 8322  NVMe SSD TM1300 M.2 1.92TB
 	6201  AM620 PCIe 3.0 NVMe SSD 128GB
 	6202  AM620 PCIe 3.0 NVMe SSD 256GB
 	6203  AM620 PCIe 3.0 NVMe SSD 512GB
@@ -26768,6 +26792,8 @@
 		1ea0 6125  NVMe SSD TP3510 U.2 15.36TB
 		1ea0 6224  NVMe SSD TP3510 E3.S 7.68TB
 		1ea0 6225  NVMe SSD TP3510 E3.S 15.36TB
+		1ea0 7124  NVMe SSD TP3512 U.2 7.68TB
+		1ea0 7125  NVMe SSD TP3512 U.2 15.36TB
 1cc5  Embedded Intelligence, Inc.
 	0100  PCIe-CAN-02 Dual CAN bus (9-pin male). PCI Express x1.
 	0101  PCIe-CAN-01 Single CAN bus (9-pin male). PCI Express x1.
@@ -27668,6 +27694,9 @@
 1de5  Eideticom, Inc
 	1000  IO Memory Controller
 	2000  NoLoad Hardware Development Kit
+	2100  NoLoad Accelerator Platform
+	2200  NoLoad Cryptographic Accelerator
+	2300  NoLoad Data Services
 	3000  eBPF-based PCIe Accelerator
 1ded  Alibaba (China) Co., Ltd.
 	107f  Elastic RDMA Adapter
@@ -27802,9 +27831,8 @@
 	05c0  PCIe 6 Fabric Switch PF6xxx [Scorpio]
 1dfc  JSC NT-COM
 	1181  TDM 8 Port E1/T1/J1 Adapter
+1e0b  Shenzhen Decenta Technology Co.,LTD
 1e0d  SambaNova Systems, Inc
-1e0e  Qualcomm / Option SimTech, Incorporated
-	9071  SIM8230G 5GNR/LTE/GNSS
 1e0f  KIOXIA Corporation
 	0001  NVMe SSD Controller BG4 (DRAM-less)
 	0007  NVMe SSD Controller Cx6
@@ -28241,6 +28269,7 @@
 	50d0  NVME RAID Card DP800
 	50d1  Flexraid6 NVMeRAID
 1e3d  Burlywood, Inc
+1e3e  Shanghai Iluvatar CoreX Semiconductor Co., Ltd.
 1e43  MaxLinear Inc
 	8904  MxL8904
 	8906  MxL8906
@@ -28470,6 +28499,7 @@
 		1ec8 12a2  Fantasy I Device
 	8900  GR308
 	8902  GR3 Audio
+	8904  GR308
 	9800  Fantasy II
 		1ec8 12a2  Fantasy II Device
 	9802  Fantasy II
@@ -28487,6 +28517,7 @@
 1ed2  FuriosaAI, Inc.
 	0000  Warboy
 	0001  RNGD
+	0002  RNGD-Plus
 	2222  RNGD-S
 1ed3  Yeston
 1ed5  Moore Threads Technology Co.,Ltd
@@ -28814,10 +28845,26 @@
 		1f0f 0001  D1055AS vDPA Ethernet Controller
 	1042  D1055AS vDPA Storage Controller
 		1f0f 0001  D1055AS vDPA Storage Controller
+	1045  D1205CQ vPDA Ethernet Controller
+		1f0f 0001  D1205CQ vPDA Ethernet Controller
+	1046  D1205CQ vPDA Storage Controller
+		1f0f 0001  D1205CQ vPDA Storage Controller
+	1047  D1205CQ RDMA Ethernet Controller
+		1f0f 0001  D1205CQ RDMA Ethernet Controller
 	1220  D1055AS Ethernet Controller
 	1221  D1055AS Ethernet Controller
 	1222  D1055AS Ethernet Controller
 	1223  D1055AS Ethernet Controller
+	1224  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1225  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1226  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1227  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
+	1228  D1205CQ Ethernet Controller
+		1f0f 0001  D1205CQ Ethernet Controller
 	1600  M16104 Family
 		1f0f 0001  N1045XS, Quad-port 10GbE, PCIe 3.0 x8
 	1601  M16104 Family Virtual Function
@@ -28838,6 +28885,7 @@
 	1a02  M16102 Family
 		1f0f 0001  N1025XT, Dual-port 10GbE, PCIe 3.0 x4, Fan
 	2022  D1055AS PCI Express Switch Upstream Port
+	2023  D1205CQ PCI Express Switch Upstream Port
 	3403  M18110 Family
 	3404  M18110 Lx Family
 	3405  M18110 Family BASE-T
@@ -28864,6 +28912,7 @@
 	350a  M18305 Family Virtual Function
 		1f0f 0001  M18305 Family Virtual Function
 	9088  D1055AS PCI Express Switch Downstream Port
+	9089  D1205CQ PCI Express Switch Downstream Port
 1f16  XConn Technologies
 	c500  XC50256 CXL2.0 Switch
 	c510  XC51256 PCIe 5.0 Switch
@@ -28993,6 +29042,10 @@
 		1f47 0006  Ethernet 25G 2P FLEXFLOW-2200R
 		1f47 0007  Ethernet 50G 2P FLEXFLOW-2200R
 		1f47 0008  Ethernet 100G 2P FLEXFLOW-2200R
+	3301  K3 Family [FLEXFLOW-3100R]
+		1f47 0001  FLEXFLOW-3100R 1*100GE Ethernet Adapter
+	3302  K3 Family [FLEXFLOW-3100R Virtual Function]
+	3303  K3 Family [CONFLUX-3100R MGMT Function]
 	4001  K2-Pro Family [CONFLUX-2200E]
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200E
 		1f47 0002  Ethernet 40G 2P CONFLUX-2200E
@@ -29051,6 +29104,7 @@
 	6002  K2-Pro Family [CONFLUX-2200X Virtual Function]
 	6003  K2-Pro Family [CONFLUX-2200X MGMT Function]
 	6004  K2-Pro Family [CONFLUX-2200X DATA Offload Engine]
+1f49  NeuReality LTD
 1f4b  Axera Semiconductor Co., Ltd
 1f52  MangoBoost Inc.
 	1008  Mango GPUBoost - RDMA
@@ -29373,6 +29427,7 @@
 2004  Smart Link Ltd.
 201f  SpacemiT
 	0001  X60 PCIe 2.0 x2 Root Complex
+	0002  X100 PCIe Root Complex
 202c  CAEN S.p.A.
 	5818  A5818
 2036  Netforward Microelectronics Co., Ltd.
@@ -29395,8 +29450,16 @@
 		2036 1005  NP36000 Virtual PCIe C2PMem 1.x Endpoint
 		2036 1006  NP36000 Virtual PCIe Pktgen 1.x Endpoint
 203b  XTX Markets Technologies Ltd.
+2044  Shenzhen Jiahua Zhongli Technology Co., LTD.
+	8200  CeaCent CS211X 12G SAS RAID controller
+		2044 2110  CeaCent CS2110-8i
+		2044 2111  CeaCent CS2110-16i
+	8201  CeaCent CS215X 12G SAS RAID controller
+		2044 2150  CeaCent CS2150-8i
+		2044 2151  CeaCent CS2150-16i
 2046  GXMICRO Technology (Shanghai) Co., Ltd.
 2048  Beijing SpaceControl Technology Co.Ltd
+2052  Frontgrade Gaisler AB
 2058  Lime Microsystems Ltd.
 205c  Zhejiang VMing Semiconductor Co., Ltd.
 	1514  EP9410 U.2 1.92TB NVME SSD
@@ -29405,6 +29468,21 @@
 	1535  EP9430 U.2 3.2TB NVME SSD
 	1536  EP9430 U.2 6.4TB NVME SSD
 205d  Shanghai Zijing Xinjie Intelligent Technology Co., Ltd.
+205e  SDTECH
+	0000  SD85xxx PCIe Gen5 Switch
+		205e 0048  SD85048 PCIe Gen 5 48 lane Switch Upstream/Downstream Port
+		205e 0096  SD85096 PCIe Gen 5 96 lane Switch Upstream/Downstream Port
+		205e 0104  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+		205e 0105  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+		205e 0144  SD85144 PCIe Gen 5 144 lane Switch Upstream/Downstream Port
+		205e 2004  SD85000 PCIe NT Endpoint
+		205e 2005  SD85000 PCIe gDMA Endpoint
+		205e 2006  SD85000 PCIe Management Endpoint
+	5048  SD85048 PCIe Gen 5 48 lane Switch Upstream/Downstream Port
+	5096  SD85096 PCIe Gen 5 96 lane Switch Upstream/Downstream Port
+	5104  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+	5105  SD85104 PCIe Gen 5 104 lane Switch Upstream/Downstream Port
+	5144  SD85144 PCIe Gen 5 144 lane Switch Upstream/Downstream Port
 2061  Unis Flash Memory
 	4000  E4000 controller
 	4100  E4100 controller
@@ -29442,6 +29520,12 @@
 		2061 2044  E5300 NVMe SSD 7.68TB PCIe 5.0 U.2
 		2061 2045  E5300 NVMe SSD 12.8TB PCIe 5.0 U.2
 		2061 2046  E5300 NVMe SSD 15.36TB PCIe 5.0 U.2
+		2061 2085  E5300 NVMe SSD 3.2TB PCIe 5.0 U.2
+		2061 2086  E5300 NVMe SSD 3.84TB PCIe 5.0 U.2
+		2061 2087  E5300 NVMe SSD 6.4TB PCIe 5.0 U.2
+		2061 2088  E5300 NVMe SSD 7.68TB PCIe 5.0 U.2
+		2061 2089  E5300 NVMe SSD 12.8TB PCIe 5.0 U.2
+		2061 208a  E5300 NVMe SSD 15.36TB PCIe 5.0 U.2
 2063  Hubei Yangtze Mason Semiconductor Technology Co., Ltd.
 	0bb8  MC3000
 	0bb9  RC3000
@@ -29555,6 +29639,9 @@
 20e3  Elix Systems SA
 20e7  TOPSSD
 20f4  TRENDnet
+20f6  Shenzhen Zhishi Network Technology Co., Ltd.
+	0001  MPU H1
+20f9  Shenzhen Silicon Dynamic Networks Co., Ltd.
 2116  ZyDAS Technology Corp.
 21b4  Hunan Goke Microelectronics Co., Ltd
 21c3  21st Century Computer Corp.
@@ -29797,10 +29884,10 @@
 	7173  CH355 PCI Quad Serial Port Controller
 434e  Cornelis Networks
 	0001  CN5000 HFI Silicon, Dual Port, BGA [discrete]
-		434e 0001  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled
-		434e 0002  CN5000 HFI Adapter, Dual Port, QSFP-DD, x16 PCIe Gen 5, Air-Cooled
-		434e 0003  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Air-Cooled, Thermally Enhanced
-		434e 0004  CN5000 HFI Adapter, Single Port, QSFP, x16 PCIe Gen 5, Conduction-Cooled
+		434e 0001  CN5000 SuperNIC, Single Port, QSFP, x16 PCIe Gen 5
+		434e 0002  CN5000 SuperNIC, Dual Port, QSFP-DD, x16 PCIe Gen 5
+		434e 0003  CN5000 SuperNIC, Single Port, QSFP, x16 PCIe Gen 5, II
+		434e 0004  CN5000 SuperNIC, Dual Port, QSFP-DD, x16 PCIe Gen 5, II
 	0002  CN6000 HFI Silicon, Dual Port, BGA [discrete]
 	8001  CN5000 Switch Silicon, 48 Port, BGA
 4444  Internext Compression Inc
@@ -31214,6 +31301,8 @@
 	0dc5  Ethernet Connection (23) I219-LM
 		1028 0c06  Precision 3580
 	0dc6  Ethernet Connection (23) I219-V
+	0dc7  Ethernet Connection I219-LM
+	0dc8  Ethernet Connection I219-V
 	0dcd  Ethernet Connection C825-X
 	0dd2  Ethernet Network Adapter I710
 		1137 0000  I710T4LG 4x1 GbE RJ45 PCIe NIC
@@ -32180,11 +32269,13 @@
 		8086 0002  Ethernet Network Adapter E835-C-Q2 for OCP 3.0
 		8086 0003  Ethernet Network Adapter E835-CC-Q1
 		8086 0004  Ethernet Network Adapter E835-CC-Q1 for OCP 3.0
+		8086 0005  Ethernet Network Adapter E835-C-Q2
 	124a  Ethernet Controller E835-CC for SFP
 		8086 0001  Ethernet Network Adapter E835-XXV-2 for OCP 3.0
 		8086 0002  Ethernet Network Adapter E835-XXV-4
 		8086 0003  Ethernet Network Adapter E835-XXV-2
 		8086 0004  Ethernet Network Adapter E835-XXV-4 for OCP 3.0
+		8086 0008  Ethernet Network Adapter E835-XXV-2
 	124b  82380FB (MPCI2) Mobile Docking Controller
 	124c  Ethernet Connection E823-L for backplane
 	124d  Ethernet Connection E823-L for SFP
@@ -32921,7 +33012,7 @@
 	1622  Broadwell-DT/H GT3 [Iris Pro Graphics 6200]
 	1626  Broadwell-U GT3 [HD Graphics 6000]
 	162a  Broadwell-DT GT3 [Iris Pro Graphics P6300]
-	162b  Iris Graphics 6100
+	162b  Broadwell-U GT3 [Iris Graphics 6100]
 	162d  Broadwell-U Integrated Graphics
 	162e  Broadwell-U Integrated Graphics
 	1632  Broadwell-U Integrated Graphics
@@ -37898,7 +37989,11 @@
 	56a3  DG2 [Arc Xe Graphics]
 	56a4  DG2 [Arc Xe Graphics]
 	56a5  DG2 [Arc A380]
+		172f 3941  A380 ELF
+		172f 3943  A380 ELF
+		172f 4017  A380 Pioneer
 	56a6  DG2 [Arc A310]
+		172f 4019  A380 ECO
 	56a7  DG2 [Arc Xe Graphics]
 	56a8  DG2 [Arc Xe Graphics]
 	56a9  DG2 [Arc Xe Graphics]
@@ -38063,6 +38158,19 @@
 	65fa  5100 Chipset PCI Express x16 Port 4-7
 	65ff  5100 Chipset DMA Engine
 	674c  CRI
+	6e23  Nova Lake PCH-S SMbus Controller
+	6e24  Nova Lake PCH-S SPI Controller
+	6e28  Nova Lake PCH-S Serial IO UART Controller #0
+	6e29  Nova Lake PCH-S Serial IO UART Controller #1
+	6e2a  Nova Lake PCH-S Serial IO SPI Controller #0
+	6e2b  Nova Lake PCH-S Serial IO SPI Controller #1
+	6e4c  Nova Lake PCH-S Serial IO I2C Controller #0
+	6e4d  Nova Lake PCH-S Serial IO I2C Controller #1
+	6e4e  Nova Lake PCH-S Serial IO I2C Controller #2
+	6e4f  Nova Lake PCH-S Serial IO I2C Controller #3
+	6e5e  Nova Lake PCH-S Serial IO SPI Controller #2
+	6e7a  Nova Lake PCH-S Serial IO I2C Controller #4
+	6e7b  Nova Lake PCH-S Serial IO I2C Controller #5
 	6f00  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2
 		15d9 0832  X10SRL-F
 	6f01  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 0
@@ -38324,6 +38432,7 @@
 	7601  82372FB PIIX5 IDE
 	7602  82372FB PIIX5 USB
 	7603  82372FB PIIX5 SMBus
+	7702  Arrow Lake-H eSPI Controller
 	7722  Arrow Lake SMBus Controller
 	7723  Arrow Lake SPI Controller
 	7725  Arrow Lake-H [PCH Serial IO UART Host Controller]
@@ -38331,10 +38440,19 @@
 	7727  Arrow Lake-H [LPC/eSPI Controller]
 	7728  Arrow Lake cAVS
 	7730  Arrow Lake-H [LPC/eSPI Controller]
+	7738  Arrow Lake-H/U PCIe Root Port #1
+	7739  Arrow Lake-H/U PCIe Root Port #2
+	773a  Arrow Lake-H/U PCIe Root Port #3
+	773b  Arrow Lake-H/U PCIe Root Port #4
+	773c  Arrow Lake-H/U PCIe Root Port #5
+	773d  Arrow Lake-H/U PCIe Root Port #6
+	773e  Arrow Lake-H/U PCIe Root Port #7
+	773f  Arrow Lake-H/U PCIe Root Port #8
 	7740  Arrow Lake CNVi WiFi
 	7745  Arrow Lake Integrated Sensor Hub
 	7746  Arrow Lake-H [LPC/eSPI Controller]
 	774c  Arrow Lake Gaussian & Neural Accelerator
+	774d  Arrow Lake-H/U PCIe Root Port #9 (PXPC)
 	7750  Arrow Lake-H [Serial IO I2C Host Controller]
 	7751  Arrow Lake-H [Serial IO I2C Host Controller]
 	7752  Arrow Lake-H [PCH Serial IO UART Host Controller]
@@ -38517,6 +38635,7 @@
 	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
 	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
 	7eca  Meteor Lake-H/U PCIe Root Port #10
+	7ecb  Arrow Lake-H/U PCIe Root Port #11 (PXPE)
 	7ecc  Meteor Lake-H PCIe Root Port #12
 	7f03  Q870 Chipset LPC/eSPI Controller
 	7f04  Z890 Chipset LPC/eSPI Controller
@@ -39437,7 +39556,7 @@
 		103c 825b  OMEN-17-w001nv
 		1043 86c7  H110I-PLUS Motherboard
 		1462 f994  H110M ECO/GAMING
-	a171  CM238 HD Audio Controller
+	a171  HM175/QM175/CM238 HD Audio Controller
 	a182  C620 Series Chipset Family SATA Controller [AHCI mode]
 	a186  C620 Series Chipset Family SATA Controller [RAID mode]
 	a190  C620 Series Chipset Family PCI Express Root Port #1
@@ -39764,7 +39883,11 @@
 	ae4c  Arrow Lake-HX Gauss Newton Algorithm (GNA)
 	ae4d  Arrow Lake-HX PCIe Root Port #13
 	ae7f  Arrow Lake-HX Shared SRAM (SOC-S)
+	b002  Panther Lake Host Bridge/DRAM Controller
+	b01d  Panther Lake Innovation Platform Framework Processor Participant
 	b03e  Panther Lake NPU
+	b05d  Panther Lake IPU
+	b07d  Panther Lake Platform Monitoring Technology (PMT)
 	b080  Panther Lake [Arc B390]
 	b081  Panther Lake [Arc B370]
 	b082  Panther Lake [Arc B390]
@@ -39815,6 +39938,11 @@
 	d156  Core Processor Semaphore and Scratchpad Registers
 	d157  Core Processor System Control and Status Registers
 	d158  Core Processor Miscellaneous Registers
+	d431  Nova Lake-S Thunderbolt 5 USB Controller
+	d433  Nova Lake-S Thunderbolt 5 NHI #0
+	d44e  Nova Lake-S Thunderbolt 5 PCI Express Root Port #0
+	d44f  Nova Lake-S Thunderbolt 5 PCI Express Root Port #1
+	d460  Nova Lake-S Thunderbolt 5 PCI Express Root Port #2
 	d740  NVL-S
 	d741  NVL-U
 	d742  NVL-H
@@ -39834,6 +39962,52 @@
 	e221  Battlemage G31 [Intel Graphics]
 	e222  Battlemage G31 [Intel Graphics]
 	e223  Battlemage G31 [Intel Graphics]
+	e302  Panther Lake LPC/eSPI Controller
+	e322  Panther Lake SMBus Controller
+	e323  Panther Lake SPI(flash) Controller
+	e325  Panther Lake Serial IO UART Controller #0
+	e326  Panther Lake Serial IO UART Controller #1
+	e327  Panther Lake Serial IO SPI Host Controller #0
+	e328  Panther Lake Smart Sound Technology BUS
+	e330  Panther Lake Serial IO SPI Host Controller #1
+	e331  Panther Lake TCSS USB3 xHCI Controller
+	e333  Panther Lake Thunderbolt 4 NHI #0
+	e334  Panther Lake Thunderbolt 4 NHI #1
+	e338  Panther Lake PCI Express Root Port A1
+	e339  Panther Lake PCI Express Root Port A2
+	e33a  Panther Lake PCI Express Root Port A3
+	e33b  Panther Lake PCI Express Root Port A4
+	e33c  Panther Lake PCI Express Root Port B1
+	e33d  Panther Lake PCI Express Root Port B2
+	e33e  Panther Lake PCI Express Root Port B3
+	e33f  Panther Lake PCI Express Root Port B4
+	e340  Panther Lake PCH CNVi WiFi
+		8086 0094  Wi-Fi 6E AX211 160MHz
+	e34e  Panther Lake Thunderbolt 4 PCI Express Root Port #0
+	e35d  Panther Lake CSME HECI #1
+	e360  Panther Lake Thunderbolt 4 PCI Express Root Port #2
+	e361  Panther Lake PCI Express Root Port C1
+	e362  Panther Lake Primary to Sideband (P2SB) Bridge IOE
+	e363  Panther Lake PCI Express Root Port C3
+	e364  Panther Lake PCI Express Root Port C4
+	e365  Panther Lake PCI Express Root Port D1
+	e366  Panther Lake PCI Express Root Port D2
+	e367  Panther Lake PCI Express Root Port D3
+	e368  Panther Lake PCI Express Root Port D4
+	e369  Panther Lake PCI Express Root Port D5
+	e36a  Panther Lake PCI Express Root Port D6
+	e36b  Panther Lake PCI Express Root Port D7
+	e36c  Panther Lake PCI Express Root Port D8
+	e36f  Panther Lake I3C Host Controller #0
+	e370  Panther Lake MEI Controller
+	e376  Panther Lake Bluetooth PCI Enumerator
+	e378  Panther Lake Serial IO I2C Controller #0
+	e379  Panther Lake Serial IO I2C Controller #1
+	e37a  Panther Lake Serial IO I2C Controller #2
+	e37b  Panther Lake Serial IO I2C Controller #3
+	e37c  Panther Lake I3C Host Controller #1
+	e37d  Panther Lake USB 3.2 xHCI Controller
+	e37f  Panther Lake Shared SRAM
 	f1a5  SSD 600P Series
 		8086 390a  SSDPEKKW256G7 256GB
 	f1a6  SSD DC P4101/Pro 7600p/760p/E 6100p Series
@@ -39922,10 +40096,22 @@
 		8088 2000  Ethernet Network Adaptor RP2000 for 10GbE SFP+
 		8088 2300  Ethernet Network Adaptor RP2000-A03 for 10GbE SFP+
 		8088 2400  Ethernet Network Adaptor RP2000-A04 for 10GbE SFP+
+	5024  Ethernet Controller WX5025 Virtual Function for 25GbE SFP28
 	5025  Ethernet Controller WX5025 for 25GbE SFP28
 		8088 1000  Dual-Port Ethernet Network Adapter FF5025-DDATACXX
+	503f  Ethernet Controller WX5040 Virtual Function for 40GbE QSFP+
+# add new id
+	5040  Ethernet Controller WX5040 for 40GbE QSFP+
+# add new id
+		8088 1000  Dual-Port Ethernet Network Adapter FF5040-DDBTACXX
+	5124  Ethernet Controller WX5025AL Virtual Function for 25GbE SFP28
 	5125  Ethernet Controller WX5025AL for 25GbE SFP28
 		8088 3000  Dual-Port Ethernet Network Adapter FF5025-DDATAIXX
+	513f  Ethernet Controller WX5040AL Virtual Function for 40GbE QSFP+
+# add new id
+	5140  Ethernet Controller WX5040AL for 40GbE QSFP+
+# add new id
+		8088 3000  Dual-Port Ethernet Network Adapter FF5040-DDBTAIXX
 80ee  InnoTek Systemberatung GmbH
 	beef  VirtualBox Graphics Adapter
 	cafe  VirtualBox Guest Service
@@ -40790,19 +40976,19 @@ d209  Ultimarc
 	1500  PAC Drive
 	15a2  SpinTrak
 	1601  AimTrak
-d20c  Chengdu BeiZhongWangXin Technology Co., Ltd.
-	5011  NE5000 Ethernet Controller
+d20c  Chengdu NorthLink Technology Co., Ltd.
+	5011  NE5025 Ethernet Controller
 		d20c e120  N5 Series 2-port 10GbE Network Adapter
 		d20c e140  N5 Series 4-port 10GbE Network Adapter
 		d20c e220  N5 Series 2-port 25GbE Network Adapter
-		d20c e221  N5S Series 2-port 25GbE Network Adapter
+		d20c e221  N5 Series 2-port 25GbE Network Adapter
 		d20c e22c  N5 Series 2-port 25GbE Network Adapter for OCP
-	6011  NE6000 Ethernet Controller
-		d20c a001  N6S Series Network Adapter
-		d20c e221  N6S Series 2-port 25GbE Network Adapter
-		d20c e281  N6S Series 8-port 25GbE Network Adapter
-		d20c e421  N6S Series 2-port 40GbE Network Adapter
-		d20c ea21  N6S Series 2-port 100GbE Network Adapter
+	6011  NE6100 Ethernet Controller
+		d20c a001  N6 Series Network Adapter
+		d20c e22e  N6 Series 2-port 25GbE Network Adapter
+		d20c e281  N6 Series 8-port 25GbE Network Adapter
+		d20c e421  N6 Series 2-port 40GbE Network Adapter
+		d20c ea21  N6 Series 2-port 100GbE Network Adapter
 d405  LeapIO
 	8200  LeapHBA
 	8201  LeapRAID


### PR DESCRIPTION
Update pci and vendor ids

## Summary by Sourcery

Bump hwdata to version 0.404 and refresh hardware identification data files.

Enhancements:
- Update PCI and vendor identification data to the latest upstream content.
- Refresh associated hardware identifier databases (e.g., IAB and OUI data files) in line with the new release version.

Build:
- Update spec file metadata and changelog for the 0.404-1 package release.