### PR TITLE
Monthly update - June 2026

### DIFF
--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.407
+Version: 0.408
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Mon Jun 01 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.408-1
+- Update pci, vendor ids
+
 * Mon May 04 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.407-1
 - Update pci, vendor ids
 

--- a/iab.txt
+++ b/iab.txt
@@ -11021,12 +11021,6 @@ DE1000-DE1FFF                 (base 16)                     ABB Transmission and
                                                             Santa Cruz  CA  95062
                                                             US
 
-40-D8-55                      (hex)                         Power Electronics Espana, S.L.
-102000-102FFF                 (base 16)                     Power Electronics Espana, S.L.
-                                                            Leonardo Da Vinci, 24-26
-                                                            Paterna  Valencia  46980
-                                                            ES
-
 00-50-C2                      (hex)                         RFL Electronics, Inc.
 ED5000-ED5FFF                 (base 16)                     RFL Electronics, Inc.
                                                             353 Powerville Road
@@ -16303,6 +16297,12 @@ B49000-B49FFF                 (base 16)                     Aplex Technology Inc
                                                             56, Avenue Raspail
                                                             Saint Maur
                                                             FR
+
+40-D8-55                      (hex)                         Power Electronics Espana, S.L.
+102000-102FFF                 (base 16)                     Power Electronics Espana, S.L.
+                                                            RONDA DEL CAMP DE AVIACIO, NO. 4 CARRASES INDUSTRIAL ESTATE
+                                                            LLÍRIA   Valencia  46160
+                                                            ES
 
 00-50-C2                      (hex)                         Timberline Manufacturing
 B5B000-B5BFFF                 (base 16)                     Timberline Manufacturing
@@ -22016,12 +22016,6 @@ FB7000-FB7FFF                 (base 16)                     Pounce Consulting
                                                             Santa Cruz  CA  95062
                                                             US
 
-00-50-C2                      (hex)                         Power Electronics Espana, S.L.
-723000-723FFF                 (base 16)                     Power Electronics Espana, S.L.
-                                                            C/ Leonardo Da Vinci, 24-26
-                                                            Paterna  Valencia  46980
-                                                            ES
-
 00-50-C2                      (hex)                         WaveIP
 AC7000-AC7FFF                 (base 16)                     WaveIP
                                                             Teradion Ind Park
@@ -27379,3 +27373,9 @@ D11000-D11FFF                 (base 16)                     Aplex Technology Inc
                                                             15F-1, No.186, Jian Yi Road
                                                             Zhonghe District  New Taipei City 235   -
                                                             TW
+
+00-50-C2                      (hex)                         Power Electronics Espana, S.L.
+723000-723FFF                 (base 16)                     Power Electronics Espana, S.L.
+                                                            RONDA DEL CAMP DE AVIACIO, NO. 4 CARRASES INDUSTRIAL ESTATE
+                                                            LLÍRIA   Valencia  46160
+                                                            ES

--- a/pci.ids
+++ b/pci.ids
@@ -1,8 +1,8 @@
 #
 #	List of PCI IDs
 #
-#	Version: 2026.05.04
-#	Date:    2026-05-04 03:15:02
+#	Version: 2026.06.01
+#	Date:    2026-06-01 03:15:02
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -787,6 +787,7 @@
 	0094  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0095  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0096  SAS3004 PCI-Express Fusion-MPT SAS-3
+		1000 3110  SAS9300-4i
 	0097  SAS3008 PCI-Express Fusion-MPT SAS-3
 		1000 3090  SAS9311-8i
 		1000 30a0  SAS9300-8e
@@ -1256,6 +1257,7 @@
 		1000 2004  PEX89000 Virtual PCIe TWC/NT 2.0 Endpoint
 # Lower lane count PEX89000 switch
 		1000 2005  PEX89000 Virtual PCIe gDMA Endpoint
+	c040  PEX90xxx PCIe Gen 6 Switch
 1001  Kolter Electronic
 	0010  PCI 1616 Measurement card with 32 digital I/O lines
 	0011  OPTO-PCI Opto-Isolated digital I/O board
@@ -1297,6 +1299,8 @@
 	131c  Kaveri [Radeon R7 Graphics]
 	131d  Kaveri [Radeon R6 Graphics]
 	13c0  Granite Ridge [Radeon Graphics]
+# Used in the Sony PlayStation 5 Phat
+	13db  Cyan Skillfish [PlayStation 5 APU]
 	13e9  Ariel/Navi10Lite
 	13f9  Oberon/Navi12Lite
 	13fe  Cyan Skillfish [BC-250]
@@ -4127,6 +4131,7 @@
 		1da2 e457  PULSE AMD Radeon RX 6500 XT
 	7446  Navi 31 USB
 	7448  Navi 31 [Radeon Pro W7900]
+	7449  Navi 31 [Radeon Pro W7800 48GB]
 	744a  Navi 31 [Radeon Pro W7900 Dual Slot]
 	744b  Navi 31 [Radeon Pro W7900D]
 	744c  Navi 31 [Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M]
@@ -4164,11 +4169,14 @@
 	74b9  Aqua Vanjaram [Instinct MI325X VF]
 	74bd  Aqua Vanjaram [Instinct MI300X HF]
 	7550  Navi 48 [Radeon RX 9070/9070 XT/9070 GRE]
+		1458 2437  Navi 48 XTX [Radeon RX 9070 XT Gaming OC ICE 16G]
 		148c 2435  Radeon RX 9070 XT 16GB
 		1849 5403  Navi 48 XTX [Steel Legend Radeon RX 9070 XT]
 		1da2 e490  Navi 48 XTX [Sapphire Pulse Radeon RX 9070 XT]
 	7551  Navi 48 [Radeon AI PRO R9700]
 	7590  Navi 44 [Radeon RX 9060 XT]
+# ASUS RX 9060 XT 16GB
+		1043 0639  Navi 44 [Radeon RX 9060 XT]
 		1458 2429  GV-R9060XTGAMING OC-16GD [Radeon RX 9060 XT GAMING OC 16G]
 		1eae 8601  RX-96TS316W7 [SWIFT RX 9060 XT OC White Triple Fan Gaming Edition 16GB]
 	75a0  Aqua Vanjaram [Instinct MI350X]
@@ -7598,7 +7606,37 @@
 	e350  80333 [SuperTrak EX24350]
 105b  Foxconn International, Inc.
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0ab  T99W175 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0b0  DW5930e 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0b1  DW5930e 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0bf  T99W175 5G Modem [Snapdragon X55]
 	e0c3  T99W175 5G Modem [Snapdragon X55]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0d8  T99W368 5G Modem [Snapdragon X65]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0d9  T99W373 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f0  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f1  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f2  T99W510 4G Modem [Snapdragon X24]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f5  DW5932e-eSIM 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e0f9  DW5932e 5G Modem [Snapdragon X62]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e118  T99W640 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e11d  DW5934e-eSIM 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e11e  DW5934e 5G Modem [Snapdragon X72]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+	e123  T99W760 5G Redcap Modem [Snapdragon X35]
 105c  Wipro Infotech Limited
 105d  Number 9 Computer Company
 	2309  Imagine 128
@@ -10209,9 +10247,7 @@
 		1102 102f  3D Blaster RIVA TNT2 Ultra
 		14af 5820  Maxi Gamer Xentor 32
 		4843 4f34  Dynamite
-	002a  NV5 [Riva TNT2]
-	002b  NV5 [Riva TNT2]
-	002c  NV5 [Vanta / Vanta LT]
+	002c  NV6 [Vanta LT / Vanta / Vanta-16]
 		1043 0200  AGP-V3800 Combat SDRAM
 		1043 0201  AGP-V3800 Combat
 		1048 0c20  TNT2 Vanta
@@ -10221,7 +10257,7 @@
 		1102 1031  CT6938 VANTA 8MB
 		1102 1034  CT6894 VANTA 16MB
 		14af 5008  Maxi Gamer Phoenix 2
-	002d  NV5 [Riva TNT2 Model 64 / Model 64 Pro]
+	002d  NV6 [Riva TNT2 Model 64 / Model 64 Pro]
 		1043 0200  AGP-V3800M
 		1043 0201  AGP-V3800M
 		1048 0c3a  Erazor III LT
@@ -13285,6 +13321,7 @@
 	2203  GA102 [GeForce RTX 3090 Ti]
 	2204  GA102 [GeForce RTX 3090]
 		10de 147d  GeForce RTX 3090 Founders Edition
+		1462 3881  MSI RTX 3090 VENTUS 3X OC
 		3842 3973  GeForce RTX 3090 XC3
 	2205  GA102 [GeForce RTX 3080 Ti 20GB]
 	2206  GA102 [GeForce RTX 3080]
@@ -13518,7 +13555,7 @@
 	28f8  AD107GLM [RTX 2000 Ada Generation Embedded GPU]
 	2900  GB100 [Reserved Dev ID A]
 	2901  GB100 [B200]
-	2909  GB100 [B200]
+	2909  GB100 [HGX B200 168GB]
 	2920  GB100 [TS4 / B100]
 	2924  GB100
 	2925  GB100
@@ -13578,10 +13615,13 @@
 # N1X
 	2e2a  GB20B [JMJWOA-Generic-GPU]
 	2f04  GB205 [GeForce RTX 5070]
+	2f06  GB205 [GeForce RTX 5060]
 	2f18  GB205M [GeForce RTX 5070 Ti Mobile]
 	2f38  GB205GLM [RTX PRO 3000 Blackwell Generation Laptop GPU]
 	2f58  GB205M [GeForce RTX 5070 Ti Mobile]
 	2f80  GB205 High Definition Audio Controller
+	3040  GR100
+	30c0  GR102
 	3180  GB110 [Reserved Dev ID A]
 	3182  GB110 [B300 SXM6 AC]
 	31a1  GB110 [GB300 MaxQ]
@@ -17199,9 +17239,25 @@
 	6348  PM63048 Switchtec PSX 48xG6 Programmable PCIe Switch
 	6360  PM63160 Switchtec PSX 160xG6 Programmable PCIe Switch
 	6364  PM63064 Switchtec PSX 64xG6 Programmable PCIe Switch
+	7044  PM70144 Switchtec PFXs 144xG7 Secure-capable Fanout PCIe Switch
+	7048  PM70048 Switchtec PFXs 48xG7 Secure-capable Fanout PCIe Switch
+	7060  PM70160 Switchtec PFXs 160xG7 Secure-capable Fanout PCIe Switch
+	7064  PM70064 Switchtec PFXs 64xG7 Secure-capable Fanout PCIe Switch
+	7144  PM71144 Switchtec PSXs 144xG7 Secure-capable Programmable PCIe Switch
+	7148  PM71048 Switchtec PSXs 48xG7 Secure-capable Programmable PCIe Switch
+	7160  PM71160 Switchtec PSXs 160xG7 Secure-capable Programmable PCIe Switch
+	7164  PM71064 Switchtec PSXs 64xG7 Secure-capable Programmable PCIe Switch
+	7244  PM72144 Switchtec PFX 144xG7 Fanout PCIe Switch
+	7248  PM72048 Switchtec PFX 48xG7 Fanout PCIe Switch
+	7260  PM72160 Switchtec PFX 160xG7 Fanout PCIe Switch
+	7264  PM72064 Switchtec PFX 64xG7 Fanout PCIe Switch
 	7364  PM7364 [FREEDM - 32 Frame Engine & Datalink Mgr]
 	7375  PM7375 [LASAR-155 ATM SAR]
 	7384  PM7384 [FREEDM - 84P672 Frm Engine & Datalink Mgr]
+	7444  PM74144 Switchtec PSX 144xG7 Programmable PCIe Switch
+	7448  PM74048 Switchtec PSX 48xG7 Programmable PCIe Switch
+	7460  PM74160 Switchtec PSX 160xG7 Programmable PCIe Switch
+	7464  PM74064 Switchtec PSX 64xG7 Programmable PCIe Switch
 	8000  PM8000  [SPC - SAS Protocol Controller]
 	8009  PM8009 SPCve 8x6G
 	8018  PM8018 Adaptec SAS Adaptor ASA-70165H PCIe Gen3 x8 6 Gbps 16-lane 4x SFF-8644
@@ -21979,6 +22035,8 @@
 	43ba  BCM43602 802.11ac Wireless LAN SoC
 	43bb  BCM43602 802.11ac Wireless LAN SoC
 	43bc  BCM43602 802.11ac Wireless LAN SoC
+	43c3  BCM4366/BCM43465 802.11ac Wave2 4x4 Wireless Network Adapter
+		1043 86fb  PCE-AC88
 	43d3  BCM43567 802.11ac Wireless Network Adapter
 	43d9  BCM43570 802.11ac Wireless Network Adapter
 	43dc  BCM4355 802.11ac Wireless LAN SoC
@@ -22862,6 +22920,8 @@
 	027c  NVLink-7 Switch in Flash Recovery Mode
 	027d  NVLink-7 Switch RMA
 	027e  Spectrum-7 Tile
+# Spectrum-8 tile
+	027f  Spectrum-8 tile
 	0281  NPS-600 Flash Recovery
 	0282  ArcusE Flash recovery
 	0283  ArcusE RMA
@@ -22886,6 +22946,10 @@
 # 400G Retimer
 	02a6  OrionR
 	02a7  OrionR RMA
+# Spectrum-8 in Flash Recovery Mode
+	02a8  Spectrum-8 in Flash Recovery Mode
+# Spectrum-8 RMA
+	02a9  Spectrum-8 RMA
 	1002  MT25400 Family [ConnectX-2 Virtual Function]
 	1003  MT27500 Family [ConnectX-3]
 		1014 04b5  PCIe3 40GbE RoCE Converged Host Bus Adapter for Power
@@ -23104,6 +23168,8 @@
 # SwitchX-2, 40GbE switch
 	c738  MT51136
 	c739  MT51136 GW
+# Spectrum-8
+	c788  Spectrum-8
 	c838  MT52236
 	c839  MT52236 router
 	caf1  ConnectX-4 CAPI Function
@@ -23184,6 +23250,7 @@
 	5049  SN8000S NVMe SSD
 	504a  WD Blue SN5000 NVMe SSD (DRAM-less)
 	5050  WD PC SN8050S / WD_BLACK SN8100 NVMe SSD
+	5062  WD PC SN5100S NVMe SSD (DRAM-less)
 	5063  WD Blue SN5100 NVMe SSD (DRAM-less)
 15b8  ADDI-DATA GmbH
 	1001  APCI1516 SP controller (16 digi outputs)
@@ -23674,7 +23741,10 @@
 		1976 2008  TEW-621PC 802.11bgn Wireless CardBus Adapter
 	0024  AR5418 Wireless Network Adapter [AR5008E 802.11(a)bgn] (PCI-Express)
 		106b 0087  AirPort Extreme
+		1154 0366  WLP-EXC-AG300 802.11abgn ExpressCard
+		1186 3a6f  DWA-643 Xtreme N Notebook ExpressCard
 		1186 3a70  DWA-556 Xtreme N PCI Express Desktop Adapter
+		1799 8071  F5D8071 v1 N1 Wireless ExpressCard
 	0027  AR9160 Wireless Network Adapter [AR9001 802.11(a)bgn]
 		0777 4082  SR71-A 802.11abgn Wireless Mini PCI Adapter
 	0029  AR922X Wireless Network Adapter
@@ -24351,6 +24421,27 @@
 	0304  SDX24 [Snapdragon X24 4G]
 	0306  SDX55 [Snapdragon X55 5G]
 	0308  SDX61/SDX62/SDX65 [Snapdragon 5G X6X-series]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e142  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e143  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e144  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e145  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e146  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e150  T99W696 5G Modem [Snapdragon X61]
+		105b e151  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e152  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e153  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e154  T99W696 5G Modem [Snapdragon X61]
+# Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/bus/mhi/host/pci_generic.c
+		105b e155  T99W696 5G Modem [Snapdragon X61]
 	0400  Datacenter Technologies QDF2432 PCI Express Root Port
 	0401  Datacenter Technologies QDF2400 PCI Express Root Port
 	1000  QCS405 PCIe Root Complex
@@ -24662,11 +24753,15 @@
 		187e 3412  NWD-310N 802.11n Wireless PCI Adapter
 	0681  RT2890 Wireless 802.11n PCIe
 		1458 e939  GN-WS30N-RH 802.11bgn Mini PCIe Card
+		1799 8073  F5D8073 v1 N Wireless ExpressCard Adapter
+		1799 807c  F5D8071 v3 N1 Wireless ExpressCard
 	0701  RT2760 Wireless 802.11n 1T/2R
 		1737 0074  WMP110 v2 802.11n RangePlus Wireless PCI Adapter
 	0781  RT2790 Wireless 802.11n 1T/2R PCIe
 		11ad 7600  HP WN7600R
+		1799 817c  F5D8073 v3 N Wireless ExpressCard Adapter
 		1814 2790  RT2790 Wireless 802.11n 1T/2R PCIe
+		1976 2600  TEW-642EC Wireless N ExpressCard
 	3060  RT3060 Wireless 802.11n 1T/1R
 		1186 3c04  DWA-525 Wireless N 150 Desktop Adapter (rev.A1)
 	3062  RT3062 Wireless 802.11n 2T/2R
@@ -25385,9 +25480,11 @@
 1993  Innominate Security Technologies AG
 1998  Toyou Feiji Electronics Co., Ltd.
 	0001  TOBOLT1 51987 NVMe SSD
+		1998 0192  TOBOLT1 45967 1920G M.2 NVMe SSD
 		1998 0384  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
 		1998 0768  TOBOLT1 51987 7680G 2.5" U.2 NVMe SSD
 		1998 2012  TOBOLT1 51987 3840G 2.5" U.2 NVMe SSD
+		1998 6144  TOBOLT1 51995 6144G 2.5" U.2 NVMe SSD
 1999  A-Logics
 	a900  AM-7209 Video Processor
 199a  Pulse-LINK, Inc.
@@ -26401,7 +26498,7 @@
 	5021  PCIe Gen4 SSD
 # 1TB
 	5026  FireCuda 540 SSD
-	5027  LaCie Rugged SSD Pro5
+	5027  BarraCuda 530 SSD / LaCie Rugged SSD Pro5
 	5100  PCIe Gen3 SSD
 	5101  PCIe Gen5 SSD
 1bb3  Bluecherry
@@ -26424,10 +26521,16 @@
 	1160  PCIe 3TE2 Controller
 	1321  PCIe 4TG-P Controller
 	1322  PCIe 4TE Controller
+	1602  PCIe 4TE3 Controller
+	160a  PCIe 4IE3 Controller
 	2262  PCIe 3TG3-P Controller
 	5208  PCIe 3TE7 Controller
-	5216  PCIe 3TE8 Controller
+	5216  PCIe 3TE9 controller
 	5236  PCIe 4TG2-P Controller
+# based on PCIe 4TG2-P Controller, for 4TS2-P series
+	523a  PCIe 4TS2-P Controller
+# based on SM8366 Controller
+	8366  PCIe 5TS-P Controller
 1bcd  Apacer Technology
 	0120  NVMe SSD Drive 960GB
 	0180  PB4480 NVMe SSD (DRAM-less)
@@ -26747,8 +26850,20 @@
 		1c5f 1421  NVMe SSD PBlaze7 7A40 1920G 2.5" U.2
 		1c5f 1431  NVMe SSD PBlaze7 7A40 3840G 2.5" U.2
 		1c5f 1441  NVMe SSD PBlaze7 7A40 7680G 2.5" U.2
+		1c5f 1631  NVMe SSD PBlaze7 7A40 3840G 2.5" U.2
+		1c5f 1641  NVMe SSD PBlaze7 7A40 7680G 2.5" U.2
+		1c5f 1651  NVMe SSD PBlaze7 7A40 15360G 2.5" U.2
+		1c5f 1661  NVMe SSD PBlaze7 7A40 30720G 2.5" U.2
+		1c5f 1751  NVMe SSD PBlaze7 7A40 Ocean 15360G 2.5" U.2
+		1c5f 1761  NVMe SSD PBlaze7 7A40 Ocean 30720G 2.5" U.2
+		1c5f 1771  NVMe SSD PBlaze7 7A40 Ocean 61440G 2.5" U.2
+		1c5f 1781  NVMe SSD PBlaze7 7A40 Ocean 122880G 2.5" U.2
 		1c5f 5431  NVMe SSD PBlaze7 7A46 3200G 2.5" U.2
 		1c5f 5441  NVMe SSD PBlaze7 7A46 6400G 2.5" U.2
+		1c5f 5631  NVMe SSD PBlaze7 7A46 3200G 2.5" U.2
+		1c5f 5641  NVMe SSD PBlaze7 7A46 6400G 2.5" U.2
+		1c5f 5651  NVMe SSD PBlaze7 7A46 12800G 2.5" U.2
+		1c5f 5661  NVMe SSD PBlaze7 7A46 25600G 2.5" U.2
 	003d  PBlaze5 920/926
 		1c5f 0a30  NVMe SSD PBlaze5 920 3840G AIC
 		1c5f 0a31  NVMe SSD PBlaze5 920 3840G 2.5" U.2
@@ -26954,6 +27069,8 @@
 	6a04  AM6A0 PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
 	6a13  RPJYJ512MKN1QWQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6a14  AM6A1 PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
+	6b02  AM6B0 PCIe 4.0 NVMe SSD 256GB (DRAM-less)
+	6b03  RPETJ512MMW1MDQ PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6b04  AM6B0 PCIe 4.0 NVMe SSD
 	6b13  AM6B1 PCIe 4.0 NVMe SSD 512GB (DRAM-less)
 	6b14  RPJYJ1T24MLR1HWY PCIe 4.0 NVMe SSD 1024GB (DRAM-less)
@@ -27367,6 +27484,7 @@
 	102d  AR-TK242-FX2 [8x10GbE Gen5 Packet Capture-Replay Device]
 	102e  AR-TK242-FX2 [8x25GbE Gen5 Packet Capture-Replay Device]
 	102f  AR-TK242-FX2 [1x400GbE Gen5 Packet Capture-Replay Device]
+	1030  AR-ARKSTREAM [Arkville Streaming DMA]
 	4200  A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 1d72  Xiaomi
 1d78  DERA Storage
@@ -28189,7 +28307,86 @@
 	0032  PCIe 4.0 NVMe SSD Controller XG10d
 	0033  Exceria Plus G4 NVMe SSD (DRAM-less)
 	0034  CM9-based E3.S NVMe SSD
+		1028 240f  KCM9FRJE1T92
+		1028 2410  KCM9FRJE3T84
+		1028 2411  KCM9FRJE7T68
+		1028 2412  KCM9FRJE15T3
+		1028 2413  KCM9FRJE30T7
+		1028 2414  KCM9XRJE1T92
+		1028 2415  KCM9XRJE3T84
+		1028 2416  KCM9XRJE7T68
+		1028 2417  KCM9XRJE15T3
+		1028 2418  KCM9XRJE30T7
+		1028 2419  KCM9FVJE1T60
+		1028 241a  KCM9FVJE3T20
+		1028 241b  KCM9FVJE6T40
+		1028 241c  KCM9FVJE12T8
+		1028 241d  KCM9XVJE1T60
+		1028 241e  KCM9XVJE3T20
+		1028 241f  KCM9XVJE6T40
+		1028 2420  KCM9XVJE12T8
 	0035  CM9-based U3 NVMe SSD
+		1028 23fb  KCM9FRUL1T92
+		1028 23fc  KCM9FRUL3T84
+		1028 23fd  KCM9FRUL7T68
+		1028 23fe  KCM9FRUL15T3
+		1028 23ff  KCM9FRUL30T7
+		1028 2400  KCM9FRUL61T4
+		1028 2401  KCM9XRUL1T92
+		1028 2402  KCM9XRUL3T84
+		1028 2403  KCM9XRUL7T68
+		1028 2404  KCM9XRUL15T3
+		1028 2405  KCM9XRUL30T7
+		1028 2406  KCM9XRUL61T4
+		1028 2407  KCM9FVUL1T60
+		1028 2408  KCM9FVUL3T20
+		1028 2409  KCM9FVUL6T40
+		1028 240a  KCM9FVUL12T8
+		1028 240b  KCM9XVUL1T60
+		1028 240c  KCM9XVUL3T20
+		1028 240d  KCM9XVUL6T40
+		1028 240e  KCM9XVUL12T8
+	0036  NVMe SSD Controller CD9P U.2
+		1028 23d5  KCD9DPUG1T92
+		1028 23d6  KCD9DPUG3T84
+		1028 23d7  KCD9DPUG7T68
+		1028 23d8  KCD9DPUG15T3
+		1028 23d9  KCD9DPUG30T7
+		1028 23da  KCD9DPUG61T4
+		1028 23db  KCD9XPUG1T92
+		1028 23dc  KCD9XPUG3T84
+		1028 23dd  KCD9XPUG7T68
+		1028 23de  KCD9XPUG15T3
+		1028 23df  KCD9XPUG30T7
+		1028 23e0  KCD9XPUG61T4
+		1028 23e1  KCD9DPUG1T60
+		1028 23e2  KCD9DPUG3T20
+		1028 23e3  KCD9DPUG6T40
+		1028 23e4  KCD9DPUG12T8
+		1028 23e5  KCD9XPUG1T60
+		1028 23e6  KCD9XPUG3T20
+		1028 23e7  KCD9XPUG6T40
+		1028 23e8  KCD9XPUG12T8
+	0037  NVMe SSD Controller CD9P E3.S
+		1028 23e9  KCD9DPJE1T92
+		1028 23ea  KCD9DPJE3T84
+		1028 23eb  KCD9DPJE7T68
+		1028 23ec  KCD9DPJE15T3
+		1028 23ed  KCD9DPJE30T7
+		1028 23ee  KCD9XPJE1T92
+		1028 23ef  KCD9XPJE3T84
+		1028 23f0  KCD9XPJE7T68
+		1028 23f1  KCD9XPJE15T3
+		1028 23f2  KCD9XPJE30T7
+		1028 23f3  KCD9DPJE1T60
+		1028 23f4  KCD9DPJE3T20
+		1028 23f5  KCD9DPJE6T40
+		1028 23f6  KCD9DPJE12T8
+		1028 23f7  KCD9XPJE1T60
+		1028 23f8  KCD9XPJE3T20
+		1028 23f9  KCD9XPJE6T40
+		1028 23fa  KCD9XPJE12T8
+	003b  Exceria Basic NVMe SSD (DRAM-less)
 	003d  LC9 E3.L NVMe SSD
 		1028 244f  RLC9GZV245T
 		1028 2450  RLC9CZV245T
@@ -28603,6 +28800,7 @@
 		1e81 f123  NVMe SSD TP6500 series U.2 3840GB
 	6206  AM620 NVMe SSD
 	6a02  AM6A0 NVMe SSD (DRAM-less)
+	6c14  RPEYJ1T24 NVMe SSD (DRAM-less)
 1e83  Huaqin Technology Co.Ltd
 1e85  HEITEC AG
 1e89  ID Quantique SA
@@ -28839,6 +29037,38 @@
 		1ee4 0625  NVMe SSD U.2 1.6TB (P8128Z3)
 		1ee4 0626  NVMe SSD U.2 3.2TB (P8128Z3)
 		1ee4 0627  NVMe SSD U.2 6.4TB (P8128Z3)
+		1ee4 0715  NVMe SSD U.2 1.92TB (P8118Z4)
+		1ee4 0716  NVMe SSD U.2 3.84TB (P8118Z4)
+		1ee4 0717  NVMe SSD U.2 7.68TB (P8118Z4)
+		1ee4 0718  NVMe SSD U.2 15.36TB (P8118Z4)
+		1ee4 0725  NVMe SSD U.2 1.6TB (P8118Z4)
+		1ee4 0726  NVMe SSD U.2 3.2TB (P8118Z4)
+		1ee4 0727  NVMe SSD U.2 6.4TB (P8118Z4)
+		1ee4 0728  NVMe SSD U.2 12.8TB (P8118Z4)
+		1ee4 0815  NVMe SSD U.2 1.92TB (P8118H4)
+		1ee4 0816  NVMe SSD U.2 3.84TB (P8118H4)
+		1ee4 0817  NVMe SSD U.2 7.68TB (P8118H4)
+		1ee4 0825  NVMe SSD U.2 1.6TB (P8118H4)
+		1ee4 0826  NVMe SSD U.2 3.2TB (P8118H4)
+		1ee4 0827  NVMe SSD U.2 6.4TB (P8118H4)
+		1ee4 0915  NVMe SSD U.2 1.92TB (P8118E2)
+		1ee4 0916  NVMe SSD U.2 3.84TB (P8118E2)
+		1ee4 0917  NVMe SSD U.2 7.68TB (P8118E2)
+		1ee4 0925  NVMe SSD U.2 1.6TB (P8118E2)
+		1ee4 0926  NVMe SSD U.2 3.2TB (P8118E2)
+		1ee4 0927  NVMe SSD U.2 6.4TB (P8118E2)
+		1ee4 0a15  NVMe SSD U.2 1.92TB (P8118H2)
+		1ee4 0a16  NVMe SSD U.2 3.84TB (P8118H2)
+		1ee4 0a17  NVMe SSD U.2 7.68TB (P8118H2)
+		1ee4 0a25  NVMe SSD U.2 1.6TB (P8118H2)
+		1ee4 0a26  NVMe SSD U.2 3.2TB (P8118H2)
+		1ee4 0a27  NVMe SSD U.2 6.4TB (P8118H2)
+		1ee4 0b15  NVMe SSD U.2 1.92TB (P8118H3)
+		1ee4 0b16  NVMe SSD U.2 3.84TB (P8118H3)
+		1ee4 0b17  NVMe SSD U.2 7.68TB (P8118H3)
+		1ee4 0b25  NVMe SSD U.2 1.6TB (P8118H3)
+		1ee4 0b26  NVMe SSD U.2 3.2TB (P8118H3)
+		1ee4 0b27  NVMe SSD U.2 6.4TB (P8118H3)
 		1ee4 3013  NVMe SSD AIC 480GB (P8118E)
 		1ee4 3014  NVMe SSD AIC 960GB (P8118E)
 		1ee4 3015  NVMe SSD AIC 1.92TB (P8118E)
@@ -28887,6 +29117,14 @@
 		1ee4 3625  NVMe SSD AIC 1.6TB (P8128Z3)
 		1ee4 3626  NVMe SSD AIC 3.2TB (P8128Z3)
 		1ee4 3627  NVMe SSD AIC 6.4TB (P8128Z3)
+		1ee4 3715  NVMe SSD AIC 1.92TB (P8118Z4)
+		1ee4 3716  NVMe SSD AIC 3.84TB (P8118Z4)
+		1ee4 3717  NVMe SSD AIC 7.68TB (P8118Z4)
+		1ee4 3718  NVMe SSD AIC 15.36TB (P8118Z4)
+		1ee4 3725  NVMe SSD AIC 1.6TB (P8118Z4)
+		1ee4 3726  NVMe SSD AIC 3.2TB (P8118Z4)
+		1ee4 3727  NVMe SSD AIC 6.4TB (P8118Z4)
+		1ee4 3728  NVMe SSD AIC 12.8TB (P8118Z4)
 		1ee4 abcd  NVMe SSD U.2
 	1181  PETA8118 NVMe E1S Series
 		1ee4 2015  NVMe SSD E1.S 1.92TB (P8118E)
@@ -28931,6 +29169,14 @@
 		1ee4 2625  NVMe SSD E1.S 1.6TB (P8128Z3)
 		1ee4 2626  NVMe SSD E1.S 3.2TB (P8128Z3)
 		1ee4 2627  NVMe SSD E1.S 6.4TB (P8128Z3)
+		1ee4 2715  NVMe SSD E1.S 1.92TB (P8118Z4)
+		1ee4 2716  NVMe SSD E1.S 3.84TB (P8118Z4)
+		1ee4 2717  NVMe SSD E1.S 7.68TB (P8118Z4)
+		1ee4 2718  NVMe SSD E1.S 15.36TB (P8118Z4)
+		1ee4 2725  NVMe SSD E1.S 1.6TB (P8118Z4)
+		1ee4 2726  NVMe SSD E1.S 3.2TB (P8118Z4)
+		1ee4 2727  NVMe SSD E1.S 6.4TB (P8118Z4)
+		1ee4 2728  NVMe SSD E1.S 12.8TB (P8118Z4)
 	1182  PETA8118 NVMe M2 Series
 		1ee4 1013  NVMe SSD M.2 480GB (P8118E)
 		1ee4 1014  NVMe SSD M.2 960GB (P8118E)
@@ -28996,6 +29242,22 @@
 		1ee4 1625  NVMe SSD M.2 1.6TB (P8128Z3)
 		1ee4 1626  NVMe SSD M.2 3.2TB (P8128Z3)
 		1ee4 1627  NVMe SSD M.2 6.4TB (P8128Z3)
+		1ee4 1714  NVMe SSD M.2 960GB (P8118Z4)
+		1ee4 1715  NVMe SSD M.2 1.92TB (P8118Z4)
+		1ee4 1716  NVMe SSD M.2 3.84TB (P8118Z4)
+		1ee4 1717  NVMe SSD M.2 7.68TB (P8118Z4)
+		1ee4 1724  NVMe SSD M.2 800GB (P8118Z4)
+		1ee4 1725  NVMe SSD M.2 1.6TB (P8118Z4)
+		1ee4 1726  NVMe SSD M.2 3.2TB (P8118Z4)
+		1ee4 1727  NVMe SSD M.2 6.4TB (P8118Z4)
+		1ee4 1814  NVMe SSD M.2 960GB (P8118H4)
+		1ee4 1815  NVMe SSD M.2 1.92TB (P8118H4)
+		1ee4 1816  NVMe SSD M.2 3.84TB (P8118H4)
+		1ee4 1817  NVMe SSD M.2 7.68TB (P8118H4)
+		1ee4 1824  NVMe SSD M.2 800GB (P8118H4)
+		1ee4 1825  NVMe SSD M.2 1.6TB (P8118H4)
+		1ee4 1826  NVMe SSD M.2 3.2TB (P8118H4)
+		1ee4 1827  NVMe SSD M.2 6.4TB (P8118H4)
 1ee9  SUSE LLC
 1eec  Viscore Technologies Ltd
 	0102  VSE250231S Dual-port 10Gb/25Gb Ethernet PCIe
@@ -29063,6 +29325,7 @@
 1f02  Beijing Dayu Technology
 1f03  Shenzhen Shichuangyi Electronics Co., Ltd
 	1202  MAP1202-Based NVMe SSD (DRAM-less)
+	1608  SCY C5000 NVMe SSD (DRAM-less)
 	2262  SM2262EN-based OEM SSD
 	2263  SM2263XT-Based NVMe SSD (DRAM-less)
 	2268  SM2268XT-Based NVMe SSD (DRAM-less)
@@ -29367,7 +29630,7 @@
 1f49  NeuReality LTD
 1f4b  Axera Semiconductor Co., Ltd
 1f52  MangoBoost Inc.
-	1008  Mango GPUBoost - RDMA
+	1008  Mango BoostX - RoCE AI
 	1020  Mango NetworkBoost - TCP
 	1022  Mango StorageBoost - NTI
 	1023  Mango StorageBoost - NTT
@@ -29399,11 +29662,15 @@
 1f82  d-Matrix
 	0011  Corsair [DMX 1000 Series]
 	00f1  JetStream [DMX F1 Transparent NIC]
+1f8c  Exascend,INC.
+	8008  SM8008 NVMe SSD [Px5 Series SSD]
+	8366  SM8366 NVMe SSD
 1f90  Quside Technologies
 	7024  QRNG PCIe Device
 	7025  QRNG PCIe Device
 1f99  Shenzhen Techwinsemi Technology Co., Ltd.
 	1202  TE3420 series / Patriot P320 M.2 NVMe SSD (DRAM-less)
+	1602  PCIe Gen4 x4 M.2 2280 (DRAM-less)
 	1608  PCIe Gen4 x4 M.2 2280
 	1f88  TE3420 PCIe Gen3 x4 M.2 2280
 	2269  XE4403 Series NVMe PCIe Gen4x4 SSD
@@ -29717,6 +29984,36 @@
 		2036 1005  NP36000 Virtual PCIe C2PMem 1.x Endpoint
 		2036 1006  NP36000 Virtual PCIe Pktgen 1.x Endpoint
 203b  XTX Markets Technologies Ltd.
+# Vendor ID 2042 assigned by PCI-SIG
+2042  Xi'an UniIC Semiconductors Co., Ltd
+# PCIe NVMe SSD
+	db00  UWSC256DDQYACC-N
+# PCIe NVMe SSD
+	db01  UWSC512DDQLBCC-N
+# PCIe NVMe SSD
+	db02  UWSC512DDQLACC-N
+# PCIe NVMe SSD
+	db03  UWSC1T0DDQLACC-N
+# PCIe NVMe SSD
+	dc00  UWSD512DDQYACA-N
+# PCIe NVMe SSD
+	dc01  UWSD1T0DDQYACA-N
+# PCIe NVMe SSD
+	dc02  UWSD2T0DDQYACA-N
+# PCIe NVMe SSD
+	dc03  UWSD1T0DDTYACA-N
+# PCIe NVMe SSD
+	dc04  UWSD2T0DDTYACA-N
+# PCIe NVMe SSD
+	dc05  UWSD4T0DDTYACA-N
+# PCIe NVMe SSD
+	dc06  UWSD512DDQYACB-N
+# PCIe NVMe SSD
+	dc07  UWSD1T0DDQYACB-N
+# PCIe NVMe SSD
+	dc08  UWSD512DDTMACA-N
+# PCIe NVMe SSD
+	dc09  UWSD1T0DDTMACA-N
 2044  Shenzhen Jiahua Zhongli Technology Co., LTD.
 	8200  CeaCent CS211X 12G SAS RAID controller
 		2044 2110  CeaCent CS2110-8i
@@ -29856,9 +30153,11 @@
 20a6  XCENA, Inc.
 20a7  EEVengers Inc.
 20a8  Rayson HI-TECH(SZ) Co., Ltd.
+	1202  RS512GSSD510 PCIe 3 NVMe SSD (DRAM-less)
 20a9  LDA Technologies Ltd.
 	1008  NEOTAPX FPGA Accelerator Card
 	1104  NEOTAPX FPGA Timing Synchronization Card
+	1200  MUX Ultimate FPGA Accelerator Card
 20b5  Shanghai StarFive Technology Co., Ltd.
 20ba  Hangzhou Hikstorage Technology Co., Ltd.
 	1202  NAND memory controller
@@ -29895,6 +30194,9 @@
 		20d8 4201  TUNAN-7V 1x400GbE Controller
 20dc  Sharetronic Data Technology Co., Ltd.
 	1202  M.2 2280 PCIe Gen3 x 4 Series.
+		1202 1256  M.2 2280 256GB 1202+N38A
+	5000  E5000 U.2 15mm 3.84TB NVMe SSD
+	5101  E5000 U.2 15mm 7.68TB NVMe SSD
 20e1  CECloud Computing Technology Co., Ltd.
 	7101  LS X710-E
 	7103  LS X710-M
@@ -29974,6 +30276,7 @@
 	502b  NV3 NVMe SSD [E29T] (DRAM-less)
 	502c  DC3000ME NVMe SSD [SC5]
 	502d  OM8TAP4 PCIe 4 NVMe SSD (QLC) (DRAM-less)
+	502f  OM3SGP4 PCIe 4 NVMe SSD (TLC)
 	5030  NV3 2230 NVMe SSD [SM2268XT2] (DRAM-less)
 	5034  NV3 NVMe SSD [E33T] (DRAM-less)
 270b  Xantel Corporation
@@ -30705,7 +31008,7 @@
 	1022  4 photo couple 4 relay Card
 	1025  16 photo couple 16 relay Card
 	4000  WatchDog Card
-6688  Zycoo Co., Ltd
+6688  GUANGZHOU MAXSUN INFORMATION TECHNOLOGY CO., LTD.
 	1200  CooVox TDM Analog Module
 	1400  CooVOX TDM GSM Module
 	1600  CooVOX TDM E1/T1 Module
@@ -30905,7 +31208,7 @@
 		10cf 16bf  LIFEBOOK E752
 	0155  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
 		8086 2010  Server Board S1200BTS
-	0156  3rd Gen Core processor Graphics Controller
+	0156  Ivy Bridge mobile GT1 [HD Graphics]
 		1043 108d  VivoBook X202EV
 	0158  Xeon E3-1200 v2/Ivy Bridge DRAM Controller
 		1043 844d  P8 series motherboard
@@ -30919,7 +31222,7 @@
 	0162  IvyBridge GT2 [HD Graphics 4000]
 		1043 84ca  P8 series motherboard
 		1849 0162  Motherboard
-	0166  3rd Gen Core processor Graphics Controller
+	0166  Ivy Bridge mobile GT2 [HD Graphics 4000]
 		1043 1517  Zenbook Prime UX31A
 		1043 2103  N56VZ
 		10cf 16c1  LIFEBOOK E752
@@ -30928,40 +31231,65 @@
 	0172  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
 	0176  3rd Gen Core processor Graphics Controller
 	0201  Arctic Sound
-	0284  Comet Lake PCH-LP LPC Premium Controller/eSPI Controller
+	0284  400 Series Chipset Family On-Package PCH-LP Prem-U LPC/eSPI Controller
 		1028 09be  Latitude 7410
-	02a3  Comet Lake PCH-LP SMBus Host Controller
+	0285  400 Series Chipset Family On-Package PCH-LP Mainstream/Base U LPC/eSPI Controller
+	02a0  400 Series Chipset Family On-Package P2SB
+	02a1  400 Series Chipset Family On-Package PMC
+	02a3  400 Series Chipset Family On-Package SMBus
 		1028 09be  Latitude 7410
-	02a4  Comet Lake SPI (flash) Controller
+	02a4  400 Series Chipset Family On-Package SPI (flash) Controller
 		1028 09be  Latitude 7410
-	02a6  Comet Lake North Peak
-	02b0  Comet Lake PCI Express Root Port #9
-	02b1  Comet Lake PCI Express Root Port #10
-	02b3  Comet Lake PCI Express Root Port #12
-	02b4  Comet Lake PCI Express Root Port #13
-	02b5  Comet Lake PCI Express Root Port #14
-	02b8  Comet Lake PCI Express Root Port #1
-	02bc  Comet Lake PCI Express Root Port #5
-	02bf  Comet Lake PCI Express Root Port #8
-	02c5  Comet Lake Serial IO I2C Host Controller
+	02a6  400 Series Chipset Family On-Package Trace Hub
+	02a8  400 Series Chipset Family On-Package UART #0
+	02a9  400 Series Chipset Family On-Package UART #1
+	02aa  400 Series Chipset Family On-Package SPI #0
+	02ab  400 Series Chipset Family On-Package SPI #1
+	02b0  400 Series Chipset Family On-Package PCIe Root Port #9
+	02b1  400 Series Chipset Family On-Package PCIe Root Port #10
+	02b2  400 Series Chipset Family On-Package PCIe Root Port #11
+	02b3  400 Series Chipset Family On-Package PCIe Root Port #12
+	02b4  400 Series Chipset Family On-Package PCIe Root Port #13
+	02b5  400 Series Chipset Family On-Package PCIe Root Port #14
+	02b6  400 Series Chipset Family On-Package PCIe Root Port #15
+	02b7  400 Series Chipset Family On-Package PCIe Root Port #16
+	02b8  400 Series Chipset Family On-Package PCIe Root Port #1
+	02b9  400 Series Chipset Family On-Package PCIe Root Port #2
+	02ba  400 Series Chipset Family On-Package PCIe Root Port #3
+	02bb  400 Series Chipset Family On-Package PCIe Root Port #4
+	02bc  400 Series Chipset Family On-Package PCIe Root Port #5
+	02bd  400 Series Chipset Family On-Package PCIe Root Port #6
+	02be  400 Series Chipset Family On-Package PCIe Root Port #7
+	02bf  400 Series Chipset Family On-Package PCIe Root Port #8
+	02c4  400 Series Chipset Family On-Package eMMC
+	02c5  400 Series Chipset Family On-Package I2C #4
 		1028 09be  Latitude 7410
-	02c8  Comet Lake PCH-LP cAVS
+	02c6  400 Series Chipset Family On-Package I2C #5
+	02c7  400 Series Chipset Family On-Package UART #2
+	02c8  400 Series Chipset Family On-Package HD Audio
 		1028 09be  Latitude 7410
-	02d3  Comet Lake SATA AHCI Controller
-	02d7  Comet Lake RAID Controller
-	02e0  Comet Lake Management Engine Interface
+	02d3  400 Series Chipset Family On-Package SATA Controller (AHCI)
+	02d5  400 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) no premium
+	02d7  400 Series Chipset Family On-Package SATA Controller (RAID 0/1/5/10) premium
+	02e0  400 Series Chipset Family On-Package MEI #1
 		1028 09be  Latitude 7410
-	02e3  Comet Lake AMT SOL Redirection
-	02e8  Serial IO I2C Host Controller
+	02e1  400 Series Chipset Family On-Package MEI #2
+	02e2  400 Series Chipset Family On-Package IDE Redirection (IDER-R)
+	02e3  400 Series Chipset Family On-Package Keyboard and Text (KT) Redirection
+	02e4  400 Series Chipset Family On-Package MEI #3
+	02e5  400 Series Chipset Family On-Package MEI #4
+	02e8  400 Series Chipset Family On-Package I2C #0
 		1028 09be  Latitude 7410
-	02e9  Comet Lake Serial IO I2C Host Controller
+	02e9  400 Series Chipset Family On-Package I2C #1
 		1028 09be  Latitude 7410
-	02ea  Comet Lake PCH-LP LPSS: I2C Controller #2
-	02ed  Comet Lake PCH-LP USB 3.1 xHCI Host Controller
+	02ea  400 Series Chipset Family On-Package I2C #2
+	02eb  400 Series Chipset Family On-Package I2C #3
+	02ed  400 Series Chipset Family On-Package USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller
 		1028 09be  Latitude 7410
-	02ef  Comet Lake PCH-LP Shared SRAM
+	02ee  400 Series Chipset Family On-Package USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	02ef  400 Series Chipset Family On-Package Shared SRAM
 		1028 09be  Latitude 7410
-	02f0  Comet Lake PCH-LP CNVi WiFi
+	02f0  400 Series Chipset Family On-Package CNVi WiFi
 		8086 0034  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9560 160MHz 2x2 [Jefferson Peak]
 		8086 0070  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
 		8086 0074  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
@@ -30969,10 +31297,11 @@
 		8086 0264  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9461 80MHz 1x1 [Jefferson Peak]
 		8086 02a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
 		8086 4070  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
-	02f5  Comet Lake PCH-LP SCS3
-	02f9  Comet Lake Thermal Subsytem
+	02f5  400 Series Chipset Family On-Package SDXC
+	02f9  400 Series Chipset Family On-Package Thermal Subsystem
 		1028 09be  Latitude 7410
-	02fc  Comet Lake Integrated Sensor Solution
+	02fb  400 Series Chipset Family On-Package SPI #2
+	02fc  400 Series Chipset Family On-Package Integrated Sensor Hub
 		1028 09be  Latitude 7410
 	0309  80303 I/O Processor PCI-to-PCI Bridge
 	030d  80312 I/O Companion Chip PCI-to-PCI Bridge
@@ -31064,43 +31393,70 @@
 	068d  HM470 Chipset LPC/eSPI Controller
 	068e  WM490 Chipset LPC/eSPI Controller
 	0697  W480 Chipset LPC/eSPI Controller
-	06a3  Comet Lake PCH SMBus Controller
-	06a4  Comet Lake PCH SPI Controller
-	06a8  Comet Lake PCH Serial IO UART Host Controller #0
-	06a9  Comet Lake PCH Serial IO UART Host Controller #1
-	06aa  Comet Lake PCH Serial IO SPI Controller #0
-	06ab  Comet Lake PCH Serial IO SPI Controller #1
-	06ac  Comet Lake PCI Express Root Port #21
-	06b0  Comet Lake PCI Express Root Port #9
-	06b8  Comet Lake PCIe Root Port #1
-	06ba  Comet Lake PCI Express Root Port #1
-	06bb  Comet Lake PCI Express Root Port #4
-	06bd  Comet Lake PCIe Port #6
-	06be  Comet Lake PCIe Root Port #7
-	06bf  Comet Lake PCIe Port #8
-	06c0  Comet Lake PCI Express Root Port #17
-	06c8  Comet Lake PCH cAVS
-	06d2  Comet Lake SATA AHCI Controller
+	06a0  400 Series Chipset Family P2SB
+	06a1  400 Series Chipset Family PMC
+	06a3  400 Series Chipset Platform SMBus
+	06a4  400 Series Chipset Family SPI (flash) Controller
+	06a6  400 Series Chipset Family Trace Hub
+	06a8  400 Series Chipset Family UART #0
+	06a9  400 Series Chipset Family UART #1
+	06aa  400 Series Chipset Family GSPI #0
+	06ab  400 Series Chipset Family GSPI #1
+	06ac  400 Series Chipset Family PCIe Root Port #21
+	06ad  400 Series Chipset Family PCIe Root Port #22
+	06ae  400 Series Chipset Family PCIe Root Port #23
+	06af  400 Series Chipset Family PCIe Root Port #24
+	06b0  400 Series Chipset Family PCIe Root Port #9
+	06b1  400 Series Chipset Family PCIe Root Port #10
+	06b2  400 Series Chipset Family PCIe Root Port #11
+	06b3  400 Series Chipset Family PCIe Root Port #12
+	06b4  400 Series Chipset Family PCIe Root Port #13
+	06b5  400 Series Chipset Family PCIe Root Port #14
+	06b6  400 Series Chipset Family PCIe Root Port #15
+	06b7  400 Series Chipset Family PCIe Root Port #16
+	06b8  400 Series Chipset Family PCIe Root Port #1
+	06b9  400 Series Chipset Family PCIe Root Port #2
+	06ba  400 Series Chipset Family PCIe Root Port #3
+	06bb  400 Series Chipset Family PCIe Root Port #4
+	06bc  400 Series Chipset Family PCIe Root Port #5
+	06bd  400 Series Chipset Family PCIe Root Port #6
+	06be  400 Series Chipset Family PCIe Root Port #7
+	06bf  400 Series Chipset Family PCIe Root Port #8
+	06c0  400 Series Chipset Family PCIe Root Port #17
+	06c1  400 Series Chipset Family PCIe Root Port #18
+	06c2  400 Series Chipset Family PCIe Root Port #19
+	06c3  400 Series Chipset Family PCIe Root Port #20
+	06c7  400 Series Chipset Family UART #2
+	06c8  400 Series Chipset Family HD Audio
+	06d2  400 Series Chipset Family SATA Controller (AHCI) (Desktop)
+	06d3  400 Series Chipset Family SATA Controller (AHCI) (Mobile)
+	06d5  400 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Mobile)
 	06d6  Comet Lake PCH-H RAID
-	06d7  Comet Lake PCH-H RAID
-	06e0  Comet Lake HECI Controller
-	06e3  Comet Lake Keyboard and Text (KT) Redirection
-	06e8  Comet Lake PCH Serial IO I2C Controller #0
-	06e9  Comet Lake PCH Serial IO I2C Controller #1
-	06ea  Comet Lake PCH Serial IO I2C Controller #2
-	06eb  Comet Lake PCH Serial IO I2C Controller #3
-	06ed  Comet Lake USB 3.1 xHCI Host Controller
-	06ef  Comet Lake PCH Shared SRAM
-	06f0  Comet Lake PCH CNVi WiFi
+	06d7  400 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Mobile)
+	06de  400 Series Chipset Family SATA Controller (AHCI) Optane Caching
+	06e0  400 Series Chipset Family HECI #1
+	06e1  400 Series Chipset Family HECI #2
+	06e2  400 Series Chipset Family IDE Redirection (IDE-R)
+	06e3  400 Series Chipset Family Keyboard and Text (KT) Redirection
+	06e4  400 Series Chipset Family HECI #3
+	06e5  400 Series Chipset Family HECI #4
+	06e8  400 Series Chipset Family I2C #0
+	06e9  400 Series Chipset Family I2C #1
+	06ea  400 Series Chipset Family I2C #2
+	06eb  400 Series Chipset Family I2C #3
+	06ed  400 Series Chipset Family USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller
+	06ef  400 Series Chipset Family Shared SRAM
+	06f0  400 Series Chipset Family CNVi Wi-Fi
 		1a56 1651  Dual Band Wi-Fi 6(802.11ax) Killer AX1650s 160MHz 2x2 [Cyclone Peak]
 		1a56 1652  Dual Band Wi-Fi 6(802.11ax) Killer AX1650i 160MHz 2x2 [Cyclone Peak]
 		8086 0034  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9560 160MHz 2x2 [Jefferson Peak]
 		8086 0074  Dual Band Wi-Fi 6(802.11ax) AX201 160MHz 2x2 [Harrison Peak]
 		8086 02a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
 		8086 42a4  Dual Band Wi-Fi 5(802.11ac) Wireless-AC 9462 80MHz 1x1 [Jefferson Peak]
-	06f9  Comet Lake PCH Thermal Controller
-	06fb  Comet Lake PCH Serial IO SPI Controller #2
-	06fc  Comet Lake PCH Integrated Sensor Solution
+	06f5  400 Series Chipset Family SCS3 SDXC
+	06f9  400 Series Chipset Family Thermal Subsystem
+	06fb  400 Series Chipset Family GSPI #2
+	06fc  400 Series Chipset Family Integrated Sensor Hub
 	0700  CE Media Processor A/V Bridge
 	0701  CE Media Processor NAND Flash Controller
 	0703  CE Media Processor Media Control Unit 1
@@ -31368,12 +31724,12 @@
 	0962  80960RM (i960RM) Bridge
 	0964  80960RP (i960RP) Microprocessor/Bridge
 	0975  Optane NVME SSD H10 with Solid State Storage [Teton Glacier]
-	0998  Ice Lake IEH
-	09a2  Ice Lake Memory Map/VT-d
-	09a3  Ice Lake RAS
-	09a4  Ice Lake Mesh 2 PCIe
-	09a6  Ice Lake MSM
-	09a7  Ice Lake PMON MSM
+	0998  Xeon 6900 6700 6500 Series with P-Cores Processors IEH
+	09a2  Xeon 6900 6700 6500 Series with P-Cores Processors VT-d
+	09a3  Xeon 6900 6700 6500 Series with P-Cores Processors RAS
+	09a4  Xeon 6900 6700 6500 Series with P-Cores Processors UFI
+	09a6  Xeon 6900 6700 6500 Series with P-Cores Processors MSM
+	09a7  Xeon 6900 6700 6500 Series with P-Cores Processors PMON MSM
 	09ab  RST VMD Managed Controller
 	09ad  Optane NVME SSD H20 with Solid State Storage [Pyramid Glacier]
 	09c4  PAC with Intel Arria 10 GX FPGA
@@ -31451,7 +31807,7 @@
 		1028 1fe8  Express Flash NVMe 2.0TB HHHL AIC (P4600)
 		1028 1fe9  Express Flash NVMe 4.0TB HHHL AIC (P4600)
 	0b00  Ice Lake CBDMA [QuickData Technology]
-	0b23  Xeon Root Event Collector
+	0b23  Xeon 6900 6700 6500 Series with P-Cores Processors IEH
 	0b25  Data Streaming Accelerator (DSA)
 	0b26  Thunderbolt 4 Bridge [Goshen Ridge 2020]
 	0b27  Thunderbolt 4 USB Controller [Goshen Ridge 2020]
@@ -31585,17 +31941,26 @@
 	0d22  Crystal Well Integrated Iris Pro Graphics 5200
 	0d26  Crystal Well Integrated Graphics Controller
 	0d36  Crystal Well Integrated Graphics Controller
-	0d4c  Ethernet Connection (11) I219-LM
-	0d4d  Ethernet Connection (11) I219-V
+	0d4c  400 Series Chipset Family GbE Controller (Corporate/vPro)
+	0d4d  400 Series Chipset Family GbE Controller (Consumer)
 		8086 0d4d  Ethernet Connection (11) I219-V
-	0d4e  Ethernet Connection (10) I219-LM
-	0d4f  Ethernet Connection (10) I219-V
+	0d4e  400 Series Chipset Family On-Package GbE Controller (Corporate/vPro)
+	0d4f  400 Series Chipset Family On-Package GbE Controller (Consumer)
 	0d53  Ethernet Connection (12) I219-LM
 	0d55  Ethernet Connection (12) I219-V
 	0d58  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0000  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 		8086 0001  Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
 	0d9f  Ethernet Controller I225-IT
+	0db0  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #0
+	0db1  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #1
+	0db2  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #2
+	0db3  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #3
+	0db4  Xeon 6900 6700 6500 Series with P-Cores Processors NTB
+	0db6  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #4
+	0db7  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #5
+	0db8  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #6
+	0db9  Xeon 6900 6700 6500 Series with P-Cores Processors PCIe and CXL.io Root Port #7
 	0dc5  Ethernet Connection (23) I219-LM
 		1028 0c06  Precision 3580
 	0dc6  Ethernet Connection (23) I219-V
@@ -33083,6 +33448,7 @@
 		8086 000c  Ethernet Network Adapter XXV710-DA2 for OCP 3.0
 		8086 000d  Ethernet 25G 2P XXV710 OCP
 		8086 4001  Ethernet Network Adapter XXV710-2
+	1590  Ethernet Connection E810-C
 	1591  Ethernet Controller E810-C for backplane
 		8086 bcce  Ethernet Controller E810-C for Intel(R) Open FPGA Stack
 	1592  Ethernet Controller E810-C for QSFP
@@ -33131,6 +33497,9 @@
 		8086 4010  Ethernet Network Adapter E810-XXV-4
 		8086 4013  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
 		8086 401c  Ethernet Network Adapter E810-XXV-4 for OCP 3.0
+	1594  Ethernet Controller E810-C/X557-AT 10GBASE-T
+	1595  Ethernet Controller E810-C 1GbE
+	1598  Ethernet Connection E810-XXV
 	1599  Ethernet Controller E810-XXV for backplane
 		8086 0001  Ethernet 25G 2P E810-XXV-k Mezz
 	159a  Ethernet Controller E810-XXV for QSFP
@@ -33154,6 +33523,8 @@
 		8086 4002  Ethernet Network Adapter E810-XXV-2 for OCP 3.0
 		8086 4003  Ethernet Network Adapter E810-XXV-2
 		8086 4015  Ethernet Network Adapter E810-XXV-2 for OCP 3.0
+	159c  Ethernet Controller E810-XXV/X557-AT 10GBASE-T
+	159d  Ethernet Controller E810-XXV 1GbE
 	15a0  Ethernet Connection (2) I218-LM
 	15a1  Ethernet Connection (2) I218-V
 	15a2  Ethernet Connection (3) I218-LM
@@ -33245,8 +33616,8 @@
 	15f4  Ethernet Connection (15) I219-LM
 	15f5  Ethernet Connection (15) I219-V
 	15f6  I210 Gigabit Ethernet Connection
-	15f9  Ethernet Connection (14) I219-LM
-	15fa  Ethernet Connection (14) I219-V
+	15f9  500 Series Chipset Family GbE Controller (Corporate/vPro)
+	15fa  500 Series Chipset Family GbE Controller (Consumer)
 	15fb  Ethernet Connection (13) I219-LM
 	15fc  Ethernet Connection (13) I219-V
 	15ff  Ethernet Controller X710 for 10GBASE-T
@@ -35357,6 +35728,7 @@
 		8086 3905  NVMe Datacenter SSD [Optane] 15mm 2.5" U.2 (P4800X)
 	2710  Dynamic Load Balancer 2.0 (DLB)
 	2714  Dynamic Load Balancer 2.5 (DLB)
+	2715  Dynamic Load Balancer (DLB) Virtual Function
 	2723  Wi-Fi 6 AX200
 		1a56 1654  Killer Wi-Fi 6 AX1650x (AX200NGW)
 		8086 0084  Wi-Fi 6 AX200NGW
@@ -35781,25 +36153,25 @@
 		1028 01da  OptiPlex 745
 		1462 7235  P965 Neo MS-7235 mainboard
 	2821  82801HR/HO/HH (ICH8R/DO/DH) 6 port SATA Controller [AHCI mode]
-	2822  SATA Controller [RAID mode]
+	2822  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Desktop RST)
 		1028 020d  Inspiron 530
 		103c 2a6f  Asus IPIBL-LB Motherboard
 		1043 8277  P5K PRO Motherboard: 82801IR [ICH9R]
 		1462 7345  MS-7345 Motherboard: Intel 82801I/IR [ICH9/ICH9R]
-	2823  sSATA Controller [RAID Mode]
+	2823  SSATA Controller (RAID 0/1/5/10)
 	2824  82801HB (ICH8) 4 port SATA Controller [AHCI mode]
 		1043 81ec  P5B
 	2825  82801HR/HO/HH (ICH8R/DO/DH) 2 port SATA Controller [IDE mode]
 		1028 01da  OptiPlex 745
 		1462 7235  P965 Neo MS-7235 mainboard
-	2826  SATA Controller [RAID Mode]
+	2826  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Server/Desktop RST)
 		1d49 0100  Intel RSTe SATA Software RAID
 		1d49 0101  Intel RSTe SATA Software RAID
 		1d49 0102  Intel RSTe SATA Software RAID
 		1d49 0103  Intel RSTe SATA Software RAID
 		1d49 0104  Intel RSTe SATA Software RAID
 		1d49 0105  Intel RSTe SATA Software RAID
-	2827  sSATA Controller [RAID Mode]
+	2827  SSATA Controller (RAID 0/1/5/10)
 	2828  82801HM/HEM (ICH8M/ICH8M-E) SATA Controller [IDE mode]
 		1028 01f3  Inspiron 1420
 		103c 30c0  Compaq 6710b
@@ -35818,7 +36190,7 @@
 		17aa 20a7  ThinkPad T61/R61
 		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 		e4bf cc47  CCG-RUMBA
-	282a  82801 Mobile SATA Controller [RAID mode]
+	282a  SATA Controller (RAID 0/1/5/10) In-box Compatible ID (Mobile RST)
 		1028 040b  Latitude E6510
 		e4bf 50c1  PC1-GROOVE
 	282b  C740 Series (Emmitsburg) Chipsets SATA2 Controller (RAID) Alternate ID
@@ -36951,10 +37323,17 @@
 	31f0  Gemini Lake Host Bridge
 	3200  GD31244 PCI-X SATA HBA
 		1775 c200  C2K onboard SATA host bus adapter
-	3245  Xeon UPI Mesh Stop M2UPI Registers
-	324a  Xeon IMC0 Mesh to Mem Registers
-	324c  Xeon Unicast Group1 CHA Registers
-	324d  Xeon Unicast Group0 CHA Registers
+	3240  Xeon 6900 6700 6500 Series with P-Cores Processors UPI Misc
+	3241  Xeon 6900 6700 6500 Series with P-Cores Processors UPI link/Phy0
+	3242  Xeon 6900 6700 6500 Series with P-Cores Processors UPI Phy0
+	3245  Xeon 6900 6700 6500 Series with P-Cores Processors UPI
+	324a  Xeon 6900 6700 6500 Series with P-Cores Processors IMC
+	324c  Xeon 6900 6700 6500 Series with P-Cores Processors CHA Unicast Group 1
+	324d  Xeon 6900 6700 6500 Series with P-Cores Processors CHA Unicast Group 0
+	3250  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Event Control
+	3251  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Register Access Control Unit
+	3252  Xeon 6900 6700 6500 Series with P-Cores Processors Ubox Decode
+	3256  Xeon 6900 6700 6500 Series with P-Cores Processors Trace Hub
 	3258  Power Control Unit (PCU) CR0
 	3259  Power Control Unit (PCU) CR1
 	325a  Power Control Unit (PCU) CR2
@@ -37047,13 +37426,13 @@
 	344b  Ice Lake PCU Registers
 	344c  Ice Lake CHA Registers
 	344d  Ice Lake CHA Registers
-	344f  Ice Lake CHA Registers
+	344f  Xeon 6900 6700 6500 Series with P-Cores Processors CHA All 0
 	3450  Ice Lake Ubox Registers
 	3451  Ice Lake Ubox Registers
 	3452  Ice Lake Ubox Registers
 	3455  Ice Lake Ubox Registers
 	3456  Ice Lake NorthPeak
-	3457  Ice Lake CHA Registers
+	3457  Xeon 6900 6700 6500 Series with P-Cores Processors CHA All 1
 	3458  Ice Lake PCU Registers
 	3459  Ice Lake PCU Registers
 	345a  Ice Lake PCU Registers
@@ -37299,15 +37678,18 @@
 	372b  Xeon C5500/C3500 Core
 	372c  Xeon C5500/C3500 Reserved
 	373f  Xeon C5500/C3500 IOxAPIC
-	37c0  C62x chipset series PCIe x16/x8 Upstream Port
-	37c2  C62x chipset series PCIe Virtual Switch Port 0
-	37c3  C62x chipset series PCIe Virtual Switch Port 1
-	37c4  C62x chipset series PCIe Virtual Switch Port 2
-	37c5  C62x chipset series PCIe Virtual Switch Port 3
-	37c8  C62x Chipset series QuickAssist Technology Physical Function 0~2
+	37b1  C620 Series Chipset Family Thermal Sensor
+	37c0  C620 Series Chipset Family PCIe Uplink (x16)
+	37c1  C620 Series Chipset Family PCIe Uplink (x8)
+	37c2  C620 Series Chipset Family Virtual Switch Port 0
+	37c3  C620 Series Chipset Family Virtual Switch Port 1
+	37c4  C620 Series Chipset Family Virtual Switch Port 2
+	37c5  C620 Series Chipset Family Virtual Switch Port 3
+	37c7  C620 Series Chipset Family Virtual Switch Port 5
+	37c8  C620 Series Chipset Family QAT
 		8086 0001  QuickAssist Adapter 8960
 		8086 0002  QuickAssist Adapter 8970
-	37c9  C62x Chipset QuickAssist Technology Virtual Function
+	37c9  C620 Series Chipset Family QAT Virtual Function
 	37cc  Ethernet Connection X722
 	37cd  Ethernet Virtual Function 700 Series
 	37ce  Ethernet Connection X722 for 10GbE backplane
@@ -37892,44 +38274,101 @@
 		8086 1216  WiMAX/WiFi Link 5150 ABG
 		8086 1311  WiMAX/WiFi Link 5150 AGN
 		8086 1316  WiMAX/WiFi Link 5150 ABG
-	4384  Q570 LPC/eSPI Controller
-	4385  Z590 LPC/eSPI Controller
-	4386  H570 LPC/eSPI Controller
-	4387  B560 LPC/eSPI Controller
-	4388  H510 LPC/eSPI Controller
-	4389  WM590 LPC/eSPI Controller
-	438a  QM580 LPC/eSPI Controller
-	438b  HM570 LPC/eSPI Controller
-	438c  C252 LPC/eSPI Controller
-	438d  C256 LPC/eSPI Controller
+	4384  Q570 Chipset eSPI Controller
+	4385  Z590 Chipset eSPI Controller
+	4386  H570 Chipset eSPI Controller
+	4387  B560 Chipset eSPI Controller
+	4388  H510 Chipset eSPI Controller
+	4389  WM590 Chipset eSPI Controller
+	438a  QM580 Chipset eSPI Controller
+	438b  HM570 Chipset eSPI Controller
+	438c  C252 Chipset eSPI Controller
+	438d  C256 Chipset eSPI Controller
 	438e  H310D LPC/eSPI Controller
-	438f  W580 LPC/eSPI Controller
+	438f  W580 Chipset eSPI Controller
 	4390  RM590E LPC/eSPI Controller
 	4391  R580E LPC/eSPI Controller
-	43a3  Tiger Lake-H SMBus Controller
-	43a4  Tiger Lake-H SPI Controller
-	43b0  Tiger Lake-H PCI Express Root Port #9
-	43b8  Tiger Lake-H PCIe Root Port #1
-	43ba  Tiger Lake-H PCIe Root Port #3
-	43bb  Tiger Lake-H PCIe Root Port #4
-	43bc  Tiger Lake-H PCI Express Root Port #5
-	43be  11th Gen Core Processor PCIe Root Port #7
-	43c0  Tiger Lake-H PCIe Root Port #17
-	43c7  Tiger Lake-H PCIe Root Port #24
-	43c8  Tiger Lake-H HD Audio Controller
-	43d3  Tiger Lake SATA AHCI Controller
-	43e0  Tiger Lake-H Management Engine Interface
-	43e3  Tiger Lake AMT SOL Redirection
-	43e8  Tiger Lake-H Serial IO I2C Controller #0
-	43e9  Tiger Lake-H Serial IO I2C Controller #1
-	43ed  Tiger Lake-H USB 3.2 Gen 2x1 xHCI Host Controller
-	43ef  Tiger Lake-H Shared SRAM
-	43f0  Tiger Lake PCH CNVi WiFi
+	43a0  500 Series Chipset Family P2SB
+	43a1  500 Series Chipset Family PMC
+	43a3  500 Series Chipset Family SMBus
+	43a4  500 Series Chipset Family SPI (flash) Controller
+	43a6  500 Series Chipset Family Trace Hub
+	43a7  500 Series Chipset Family UART #2
+	43a8  500 Series Chipset Family UART #0
+	43a9  500 Series Chipset Family UART #1
+	43aa  500 Series Chipset Family GSPI #0
+	43ab  500 Series Chipset Family GSPI #1
+	43ad  500 Series Chipset Family I2C #4
+	43ae  500 Series Chipset Family I2C #5
+	43b0  500 Series Chipset Family PCIe Root Port #9
+	43b1  500 Series Chipset Family PCIe Root Port #10
+	43b2  500 Series Chipset Family PCIe Root Port #11
+	43b3  500 Series Chipset Family PCIe Root Port #12
+	43b4  500 Series Chipset Family PCIe Root Port #13
+	43b5  500 Series Chipset Family PCIe Root Port #14
+	43b6  500 Series Chipset Family PCIe Root Port #15
+	43b7  500 Series Chipset Family PCIe Root Port #16
+	43b8  500 Series Chipset Family PCIe Root Port #1
+	43b9  500 Series Chipset Family PCIe Root Port #2
+	43ba  500 Series Chipset Family PCIe Root Port #3
+	43bb  500 Series Chipset Family PCIe Root Port #4
+	43bc  500 Series Chipset Family PCIe Root Port #5
+	43bd  500 Series Chipset Family PCIe Root Port #6
+	43be  500 Series Chipset Family PCIe Root Port #7
+	43bf  500 Series Chipset Family PCIe Root Port #8
+	43c0  500 Series Chipset Family PCIe Root Port #17
+	43c1  500 Series Chipset Family PCIe Root Port #18
+	43c2  500 Series Chipset Family PCIe Root Port #19
+	43c3  500 Series Chipset Family PCIe Root Port #20
+	43c4  500 Series Chipset Family PCIe Root Port #21
+	43c5  500 Series Chipset Family PCIe Root Port #22
+	43c6  500 Series Chipset Family PCIe Root Port #23
+	43c7  500 Series Chipset Family PCIe Root Port #24
+	43c8  500 Series Chipset Family HD Audio
+	43c9  500 Series Chipset Family HD Audio
+	43ca  500 Series Chipset Family HD Audio
+	43cb  500 Series Chipset Family HD Audio
+	43cc  500 Series Chipset Family HD Audio
+	43cd  500 Series Chipset Family HD Audio
+	43ce  500 Series Chipset Family HD Audio
+	43cf  500 Series Chipset Family HD Audio
+	43d0  500 Series Chipset Family Touch Host Controller (THC) #0
+	43d1  500 Series Chipset Family Touch Host Controller (THC) #1
+	43d2  500 Series Chipset Family SATA Controller (AHCI) (Server/Desktop)
+	43d3  500 Series Chipset Family SATA Controller (AHCI) (Mobile)
+	43d4  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Desktop)
+	43d5  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) no premium (Mobile)
+	43d6  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Server/Desktop)
+	43d7  500 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium (Mobile)
+	43d8  500 Series Chipset Family I2C #6
+	43da  500 Series Chipset Family UART #3
+	43e0  500 Series Chipset Family CSME HECI #1
+	43e1  500 Series Chipset Family CSME HECI #2
+	43e2  500 Series Chipset Family CSME IDE Redirection (IDE-R)
+	43e3  500 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	43e4  500 Series Chipset Family CSME HECI #3
+	43e5  500 Series Chipset Family CSME HECI #4
+	43e8  500 Series Chipset Family I2C #0
+	43e9  500 Series Chipset Family I2C #1
+	43ea  500 Series Chipset Family I2C #2
+	43eb  500 Series Chipset Family I2C #3
+	43ed  500 Series Chipset Family USB 3.2 Gen 2x2 (20 Gbs) xHCI Host Controller
+	43ee  500 Series Chipset Family USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	43ef  500 Series Chipset Family Shared SRAM
+	43f0  500 Series Chipset Family CNVi Wi-Fi
 		8086 0034  Wireless-AC 9560
 		8086 0074  Wi-Fi 6 AX201 160MHz
 		8086 0264  Wireless-AC 9461
 		8086 02a4  Wireless-AC 9462
-	43fc  Tiger Lake-H Integrated Sensor Hub
+	43f1  500 Series Chipset Family CNVi Wi-Fi
+	43f2  500 Series Chipset Family CNVi Wi-Fi
+	43f3  500 Series Chipset Family CNVi Wi-Fi
+	43f5  500 Series Chipset Family CNVi Bluetooth
+	43f6  500 Series Chipset Family CNVi Bluetooth
+	43f7  500 Series Chipset Family CNVi Bluetooth
+	43fb  500 Series Chipset Family GSPI #2
+	43fc  500 Series Chipset Family Integrated Sensor Hub
+	43fd  500 Series Chipset Family GSPI #3
 	444e  Turbo Memory Controller
 	4511  Elkhart Lake Gaussian and Neural Accelerator
 	4538  Elkhart Lake PCI-e Root Complex
@@ -38268,8 +38707,8 @@
 	5503  Ethernet Controller I226-LMvP
 	550a  Ethernet Connection (18) I219-LM
 	550b  Ethernet Connection (18) I219-LM
-	550c  Ethernet Connection (19) I219-LM
-	550d  Ethernet Connection (19) I219-V
+	550c  800 Series Chipset Family GbE Controller (Corporate/vPro)
+	550d  800 Series Chipset Family GbE Controller (Consumer)
 	550e  Ethernet Connection (20) I219-LM
 	550f  Ethernet Connection (20) I219-V
 	5510  Ethernet Connection (21) I219-LM
@@ -38318,9 +38757,12 @@
 	5785  JHL9540 Thunderbolt 4 USB Controller [Barlow Ridge Host 40G 2023]
 	5786  JHL9480 Thunderbolt 5 80/120G Bridge [Barlow Ridge Hub 80G 2023]
 	5787  JHL9480 Thunderbolt 5 80/120G USB Controller [Barlow Ridge Hub 80G 2023]
-	5794  Granite Rapids SPI Controller
-	5795  Granite Rapids Chipset LPC Controller
-	5796  Granite Rapids SMBus Controller
+	5792  Xeon 6900 6700 6500 Series with P-Cores Processors ILMI
+	5793  Xeon 6900 6700 6500 Series with P-Cores Processors ACPI
+	5794  Xeon 6900 6700 6500 Series with P-Cores Processors SPI
+	5795  Xeon 6900 6700 6500 Series with P-Cores Processors eSPI
+	5796  Xeon 6900 6700 6500 Series with P-Cores Processors SMBus
+	5797  Xeon 6900 6700 6500 Series with P-Cores Processors UART
 	579c  Ethernet Connection E825-C for backplane
 	579d  Ethernet Connection E825-C for QSFP
 	579e  Ethernet Connection E825-C for SFP
@@ -38329,15 +38771,16 @@
 	57a1  Ethernet Connection (24) I219-V
 	57a4  JHL9440 Thunderbolt 4 Bridge [Barlow Ridge Hub 40G 2023]
 	57a5  JHL9440 Thunderbolt 4 USB Controller [Barlow Ridge Hub 40G 2023]
-	57ad  E610 Virtual Function
+	57ac  Ethernet Controller E610
+	57ad  Ethernet Controller E610 Virtual Function
 	57ae  Ethernet Controller E610 Backplane
 	57af  Ethernet Controller E610 SFP
-	57b0  Ethernet Controller E610 10GBASE T
+	57b0  Ethernet Controller E610-XT/E610-XT2 10GBASE-T
 		8086 0001  Ethernet Network Adapter E610-XT4
 		8086 0002  Ethernet Network Adapter E610-XT2
 		8086 0003  Ethernet Network Adapter E610-XT4 for OCP 3.0
 		8086 0004  Ethernet Network Adapter E610-XT2 for OCP 3.0
-	57b1  Ethernet Controller E610 2.5GBASE T
+	57b1  Ethernet Controller E610-AT2 1000BASE-T
 		8086 0000  Ethernet Converged Network Adapter E610
 		8086 0002  Ethernet Network Adapter E610-IT4
 		8086 0003  Ethernet Network Adapter E610-IT4 for OCP 3.0
@@ -38430,12 +38873,13 @@
 	5ae8  Celeron N3350/Pentium N4200/Atom E3900 Series Low Pin Count Interface
 	5aee  Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #4
 	5af0  Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge
+	6400  Core Ultra 200V Series Processors with 4 P-Cores 4 E-Cores Host Bridge
 	641d  Lunar Lake-M Dynamic Tuning Technology
 	6420  Lunar Lake [Intel Graphics]
 	643e  Lunar Lake NPU
 	645d  Lunar Lake IPU
 	647d  Lunar Lake-M Crashlog and Telemetry
-	64a0  Lunar Lake [Intel Arc Graphics 130V / 140V]
+	64a0  Core Ultra 200V Series Processors Arc Graphics 130V/140V GPU
 	64b0  Lunar Lake [Intel Graphics]
 	65c0  5100 Chipset Memory Controller Hub
 	65e2  5100 Chipset PCI Express x4 Port 2
@@ -38458,6 +38902,10 @@
 	65fa  5100 Chipset PCI Express x16 Port 4-7
 	65ff  5100 Chipset DMA Engine
 	674c  CRI
+	674d  CRI
+	674e  CRI
+	674f  CRI
+	6750  CRI
 	6e23  Nova Lake PCH-S SMbus Controller
 	6e24  Nova Lake PCH-S SPI Controller
 	6e28  Nova Lake PCH-S Serial IO UART Controller #0
@@ -38726,6 +39174,8 @@
 	71a1  440GX - 82443GX AGP bridge
 	71a2  440GX - 82443GX Host bridge (AGP disabled)
 		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
+	7202  Core Ultra 200H Series Processors eSPI Controller
+	7203  Core Ultra 200V Series Processors eSPI Controller
 	7360  XMM7360 LTE Advanced Modem
 	7560  XMM7560 LTE Advanced Pro Modem
 	7600  82372FB PIIX5 ISA
@@ -38733,37 +39183,55 @@
 	7602  82372FB PIIX5 USB
 	7603  82372FB PIIX5 SMBus
 	7702  Arrow Lake-H eSPI Controller
-	7722  Arrow Lake SMBus Controller
-	7723  Arrow Lake SPI Controller
-	7725  Arrow Lake-H [PCH Serial IO UART Host Controller]
-	7726  Arrow Lake-H PCH Serial IO UART Host Controller]
-	7727  Arrow Lake-H [LPC/eSPI Controller]
-	7728  Arrow Lake cAVS
+	7720  Core Ultra 200H/200V Series Processors P2SB (SOC)
+	7721  Core Ultra 200H/200V Series Processors PMC (SOC)
+	7722  Core Ultra 200H/200V Series Processors SMBus
+	7723  Core Ultra 200H/200V Series Processors SPI (flash) Controller
+	7724  Core Ultra 200H/200V Series Processors Trace Hub
+	7725  Core Ultra 200H/200V Series Processors UART #0
+	7726  Core Ultra 200H/200V Series Processors UART #1
+	7727  Core Ultra 200H/200V Series Processors GSPI #0
+	7728  Core Ultra 200H/200V Series Processors HD Audio
 	7730  Arrow Lake-H [LPC/eSPI Controller]
-	7738  Arrow Lake-H/U PCIe Root Port #1
-	7739  Arrow Lake-H/U PCIe Root Port #2
-	773a  Arrow Lake-H/U PCIe Root Port #3
-	773b  Arrow Lake-H/U PCIe Root Port #4
-	773c  Arrow Lake-H/U PCIe Root Port #5
-	773d  Arrow Lake-H/U PCIe Root Port #6
-	773e  Arrow Lake-H/U PCIe Root Port #7
-	773f  Arrow Lake-H/U PCIe Root Port #8
+	7738  Core Ultra 200H/200V Series Processors PCIe Root Port #1
+	7739  Core Ultra 200H/200V Series Processors PCIe Root Port #2
+	773a  Core Ultra 200H/200V Series Processors PCIe Root Port #3
+	773b  Core Ultra 200H/200V Series Processors PCIe Root Port #4
+	773c  Core Ultra 200H/200V Series Processors PCIe Root Port #5
+	773d  Core Ultra 200H/200V Series Processors PCIe Root Port #6
+	773e  Core Ultra 200H/200V Series Processors PCIe Root Port #7
+	773f  Core Ultra 200H/200V Series Processors PCIe Root Port #8
 	7740  Arrow Lake CNVi WiFi
-	7745  Arrow Lake Integrated Sensor Hub
-	7746  Arrow Lake-H [LPC/eSPI Controller]
-	774c  Arrow Lake Gaussian & Neural Accelerator
-	774d  Arrow Lake-H/U PCIe Root Port #9 (PXPC)
-	7750  Arrow Lake-H [Serial IO I2C Host Controller]
-	7751  Arrow Lake-H [Serial IO I2C Host Controller]
-	7752  Arrow Lake-H [PCH Serial IO UART Host Controller]
-	7770  Arrow Lake HECI Controller #1
-	7773  Arrow Lake Keyboard and Text (KT) Redirection
-	7778  Arrow Lake-H [Serial IO I2C Host Controller]
-	7779  Arrow Lake-H [Serial IO I2C Host Controller]
-	777a  Arrow Lake-H [Serial IO I2C Host Controller]
-	777b  Arrow Lake-H [Serial IO I2C Host Controller]
+	7745  Core Ultra 200H/200V Series Processors Integrated Sensor Hub
+	7746  Core Ultra 200H/200V Series Processors GSPI #2
+	7748  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #0 ID1
+	7749  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #0 ID2
+	774a  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #1 ID1
+	774b  Core Ultra 200H/200V Series Processors Touch Host Controller (THC) #1 ID2
+	774c  Core Ultra 200H/200V Series Processors Gaussian & Neural-Network Accelerator (GNA)
+	774d  Core Ultra 200H/200V Series Processors PCIe Root Port #9 (PXPC)
+	7750  Core Ultra 200H/200V Series Processors I2C #4
+	7751  Core Ultra 200H/200V Series Processors I2C #5
+	7752  Core Ultra 200H/200V Series Processors UART #2
+	7758  Core Ultra 200H/200V Series Processors CSME HECI #1
+	7759  Core Ultra 200H/200V Series Processors CSME HECI #2
+	775a  Core Ultra 200H/200V Series Processors CSME HECI #3
+	7763  Core Ultra 200H/200V Series Processors SATA Controller (AHCI)
+	7767  Core Ultra 200H/200V Series Processors SATA Controller (RAID 0/1/5/10) premium
+	7770  Core Ultra 200H/200V Series Processors CSME HECI #1
+	7771  Core Ultra 200H/200V Series Processors CSME HECI #2
+	7772  Core Ultra 200H/200V Series Processors CSME IDE Redirection (IDE-R)
+	7773  Core Ultra 200H/200V Series Processors CSME Keyboard and Text (KT) Redirection
+	7774  Core Ultra 200H/200V Series Processors CSME HECI #3
+	7775  Core Ultra 200H/200V Series Processors CSME HECI #4
+	7778  Core Ultra 200H/200V Series Processors I2C #0
+	7779  Core Ultra 200H/200V Series Processors I2C #1
+	777a  Core Ultra 200H/200V Series Processors I2C #2
+	777b  Core Ultra 200H/200V Series Processors I2C #3
+	777c  Core Ultra 200H/200V Series Processors I3C
 	777d  Arrow Lake USB 3.2 xHCI Controller
-	777f  Arrow Lake Shared SRAM
+	777e  Core Ultra 200H/200V Series Processors Standalone USB Device Controller
+	777f  Core Ultra 200H/200V Series Processors Shared SRAM
 	7800  82740 (i740) AGP Graphics Accelerator
 		003d 0008  Starfighter AGP
 		003d 000b  Starfighter AGP
@@ -38772,122 +39240,183 @@
 		10b4 202f  Lightspeed 740
 		8086 0000  Terminator 2x/i
 		8086 0100  Intel740 Graphics Accelerator
-	7a04  Z790 Chipset LPC/eSPI Controller
-	7a05  H770 Chipset LPC/eSPI Controller
-	7a06  B760 Chipset LPC/eSPI Controller
-	7a0c  HM770 Chipset LPC/eSPI Controller
+	7a04  Z790 Chipset eSPI Controller
+	7a05  H770 Chipset eSPI Controller
+	7a06  B760 Chipset eSPI Controller
+	7a0c  HM770 Chipset eSPI Controller
 	7a0d  WM790 Chipset LPC/eSPI Controller
-	7a13  C266 Chipset LPC/eSPI Controller
-	7a14  C262 Chipset LPC/eSPI Controller
-	7a20  700 Series Chipset P2SB
-	7a21  700 Series Chipset Power Management Controller
-	7a23  700 Series Chipset SMBus Controller
-	7a24  Raptor Lake SPI (flash) Controller
-	7a27  Raptor Lake PCH Shared SRAM
-	7a28  700 Series Chipset Serial IO UART Controller #0
-	7a29  700 Series Chipset Serial IO UART Controller #1
-	7a2a  700 Series Chipset Serial IO GSPI Controller #0
-	7a2b  700 Series Chipset Serial IO GSPI Controller #1
-	7a30  Raptor Lake PCI Express Root Port #9
-	7a31  Raptor Lake PCI Express Root Port #10
-	7a32  Raptor Lake PCI Express Root Port #11
-	7a33  Raptor Lake PCI Express Root Port #12
-	7a34  Raptor Lake PCI Express Root Port #13
-	7a35  Raptor Lake PCI Express Root Port #14
-	7a36  Raptor Lake PCI Express Root Port #15
-	7a37  Raptor Lake PCI Express Root Port #16
-	7a38  Raptor Lake PCI Express Root Port #1
-	7a39  Raptor Lake PCI Express Root Port #2
-	7a3a  Raptor Lake PCI Express Root Port #3
-	7a3b  Raptor Lake PCI Express Root Port #4
-	7a3c  Raptor Lake PCI Express Root Port #5
-	7a3d  Raptor Lake PCI Express Root Port #6
-	7a3e  Raptor Lake PCI Express Root Port #7
-	7a3f  Raptor Lake PCI Express Root Port #8
-	7a40  Raptor Lake PCI Express Root Port #17
-	7a41  Raptor Lake PCI Express Root Port #18
-	7a42  Raptor Lake PCI Express Root Port #19
-	7a43  Raptor Lake PCI Express Root Port #20
-	7a44  Raptor Lake PCI Express Root Port #21
-	7a45  Raptor Lake PCI Express Root Port #22
-	7a46  Raptor Lake PCI Express Root Port #23
-	7a47  Raptor Lake PCI Express Root Port #24
-	7a48  Raptor Lake PCI Express Root Port #25
-	7a49  Raptor Lake PCI Express Root Port #26
-	7a4a  Raptor Lake PCI Express Root Port #27
-	7a4b  Raptor Lake PCI Express Root Port #28
-	7a4c  Raptor Lake Serial IO I2C Host Controller #0
-	7a4d  Raptor Lake Serial IO I2C Host Controller #1
-	7a4e  Raptor Lake Serial IO I2C Host Controller #2
-	7a4f  Raptor Lake Serial IO I2C Host Controller #3
-	7a50  Raptor Lake High Definition Audio Controller
-	7a5c  700 Series Chipset Serial IO UART Controller #3
-	7a60  Raptor Lake USB 3.2 Gen 2x2 (20 Gb/s) XHCI Host Controller
-	7a61  Raptor Lake USB 3.2 Gen 1x1 (5 Gb/s) xDCI Device Controller
-	7a62  Raptor Lake SATA AHCI Controller
-	7a68  Raptor Lake CSME HECI #1
-	7a69  Raptor Lake CSME HECI #2
-	7a6a  Raptor Lake CSME IDE Redirection
-	7a6b  Raptor Lake CSME Keyboard and Text (KT) Redirection
-	7a6c  Raptor Lake CSME HECI #3
-	7a6d  Raptor Lake CSME HECI #4
-	7a70  700 Series Chipset CNVi WiFi
+	7a13  C266 Chipset eSPI Controller
+	7a14  C262 Chipset eSPI Controller
+	7a20  700 Series Chipset Family P2SB
+	7a21  700 Series Chipset Family PMC
+	7a23  700 Series Chipset Family SMBus
+	7a24  700 Series Chipset Family SPI (flash) Controller
+	7a26  700 Series Chipset Family Trace Hub
+	7a27  700 Series Chipset Family Shared SRAM
+	7a28  700 Series Chipset Family UART #0
+	7a29  700 Series Chipset Family UART #1
+	7a2a  700 Series Chipset Family GSPI #0
+	7a2b  700 Series Chipset Family GSPI #1
+	7a30  700 Series Chipset Family PCIe Root Port #9
+	7a31  700 Series Chipset Family PCIe Root Port #10
+	7a32  700 Series Chipset Family PCIe Root Port #11
+	7a33  700 Series Chipset Family PCIe Root Port #12
+	7a34  700 Series Chipset Family PCIe Root Port #13
+	7a35  700 Series Chipset Family PCIe Root Port #14
+	7a36  700 Series Chipset Family PCIe Root Port #15
+	7a37  700 Series Chipset Family PCIe Root Port #16
+	7a38  700 Series Chipset Family PCIe Root Port #1
+	7a39  700 Series Chipset Family PCIe Root Port #2
+	7a3a  700 Series Chipset Family PCIe Root Port #3
+	7a3b  700 Series Chipset Family PCIe Root Port #4
+	7a3c  700 Series Chipset Family PCIe Root Port #5
+	7a3d  700 Series Chipset Family PCIe Root Port #6
+	7a3e  700 Series Chipset Family PCIe Root Port #7
+	7a3f  700 Series Chipset Family PCIe Root Port #8
+	7a40  700 Series Chipset Family PCIe Root Port #17
+	7a41  700 Series Chipset Family PCIe Root Port #18
+	7a42  700 Series Chipset Family PCIe Root Port #19
+	7a43  700 Series Chipset Family PCIe Root Port #20
+	7a44  700 Series Chipset Family PCIe Root Port #21
+	7a45  700 Series Chipset Family PCIe Root Port #22
+	7a46  700 Series Chipset Family PCIe Root Port #23
+	7a47  700 Series Chipset Family PCIe Root Port #24
+	7a48  700 Series Chipset Family PCIe Root Port #25
+	7a49  700 Series Chipset Family PCIe Root Port #26
+	7a4a  700 Series Chipset Family PCIe Root Port #27
+	7a4b  700 Series Chipset Family PCIe Root Port #28
+	7a4c  700 Series Chipset Family I2C Controller #0
+	7a4d  700 Series Chipset Family I2C Controller #1
+	7a4e  700 Series Chipset Family I2C Controller #2
+	7a4f  700 Series Chipset Family I2C Controller #3
+	7a50  700 Series Chipset Family HD Audio
+	7a51  700 Series Chipset Family HD Audio
+	7a52  700 Series Chipset Family HD Audio
+	7a53  700 Series Chipset Family HD Audio
+	7a54  700 Series Chipset Family HD Audio
+	7a55  700 Series Chipset Family HD Audio
+	7a56  700 Series Chipset Family HD Audio
+	7a57  700 Series Chipset Family HD Audio
+	7a5c  700 Series Chipset Family UART #3
+	7a60  700 Series Chipset Family USB 3.2 Gen 2x2 (20 Gbs) xHCI Host Controller
+	7a61  700 Series Chipset Family USB 3.2 Gen 1x1 (5 Gbs) Device Controller (xDCI)
+	7a62  700 Series Chipset Family SATA Controller (AHCI)
+	7a68  700 Series Chipset Family CSME HECI #1
+	7a69  700 Series Chipset Family CSME HECI #2
+	7a6a  700 Series Chipset Family CSME IDE Redirection (IDE-R)
+	7a6b  700 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	7a6c  700 Series Chipset Family CSME HECI #3
+	7a6d  700 Series Chipset Family CSME HECI #4
+	7a70  700 Series Chipset Family CNVi Wi-Fi
 		8086 0074  Wi-Fi 6 AX201 160MHz
 		8086 0090  WiFi 6E AX211 160MHz
-	7a79  700 Series Chipset Serial IO GSPI Controller #3
-	7a7b  700 Series Chipset Serial IO GSPI Controller #2
-	7a7c  Raptor Lake Serial IO I2C Host Controller #4
-	7a7d  Raptor Lake Serial IO I2C Host Controller #5
-	7a7e  700 Series Chipset Serial IO UART Controller #2
-	7a83  Q670 Chipset LPC/eSPI Controller
-# Unlike other PCH components. The eSPI controller is specific to each chipset model
-	7a84  Z690 Chipset LPC/eSPI Controller
-	7a85  H670 Chipset LPC/eSPI Controller
-	7a86  B660 Chipset LPC/eSPI Controller
-	7a87  H610 Chipset LPC/eSPI Controller
-	7a88  W680 Chipset LPC/eSPI Controller
-	7a8c  HM670 Chipset LPC/eSPI Controller
-	7a8d  WM690 Chipset LPC/eSPI Controller
-	7aa3  Alder Lake-S PCH SMBus Controller
-	7aa4  Alder Lake-S PCH SPI Controller
-	7aa7  Alder Lake-S PCH Shared SRAM
-	7aa8  Alder Lake-S PCH Serial IO UART #0
-	7aab  Alder Lake-S PCH Serial IO SPI Controller #1
-	7ab0  Alder Lake-S PCH PCI Express Root Port #9
-	7ab4  Alder Lake-S PCH PCI Express Root Port #13
-	7ab8  Alder Lake-S PCH PCI Express Root Port #1
-	7ab9  Alder Lake-S PCH PCI Express Root Port #2
-	7aba  Alder Lake-S PCH PCI Express Root Port #3
-	7abc  Alder Lake-S PCH PCI Express Root Port #5
-	7abd  Alder Lake-S PCH PCI Express Root Port #6
-	7abf  Alder Lake-S PCH PCI Express Root Port #8
-	7ac4  Alder Lake-S PCH PCI Express Root Port #21
-	7ac8  Alder Lake-S PCH PCI Express Root Port #25
-	7acc  Alder Lake-S PCH Serial IO I2C Controller #0
-	7acd  Alder Lake-S PCH Serial IO I2C Controller #1
-	7ace  Alder Lake-S PCH Serial IO I2C Controller #2
-	7acf  Alder Lake-S PCH Serial IO I2C Controller #3
-	7ad0  Alder Lake-S HD Audio Controller
-	7ae0  Alder Lake-S PCH USB 3.2 Gen 2x2 XHCI Controller
-	7ae1  Alder Lake-S PCH USB 3.2 Gen 1x1 xDCI Controller
-	7ae2  Alder Lake-S PCH SATA Controller [AHCI Mode]
-	7ae8  Alder Lake-S PCH HECI Controller #1
-	7aeb  Alder Lake-S Keyboard and Text (KT) Redirection
-	7af0  Alder Lake-S PCH CNVi WiFi
+	7a71  700 Series Chipset Family CNVi Wi-Fi
+	7a72  700 Series Chipset Family CNVi Wi-Fi
+	7a73  700 Series Chipset Family CNVi Wi-Fi
+	7a78  700 Series Chipset Family Integrated Sensor Hub
+	7a79  700 Series Chipset Family GSPI #3
+	7a7b  700 Series Chipset Family GSPI #2
+	7a7c  700 Series Chipset Family I2C Controller #4
+	7a7d  700 Series Chipset Family I2C Controller #5
+	7a7e  700 Series Chipset Family UART #2
+	7a83  Q670 Chipset eSPI Controller
+	7a84  Z690 Chipset eSPI Controller
+	7a85  H670 Chipset eSPI Controller
+	7a86  B660 Chipset eSPI Controller
+	7a87  H610 Chipset eSPI Controller
+	7a88  W680 Chipset eSPI Controller
+	7a8a  W790 Chipset eSPI Controller
+	7a8c  HM670 Chipset eSPI Controller
+	7a8d  WM690 Chipset eSPI Controller
+	7aa0  600 Series Chipset Family P2SB
+	7aa1  600 Series Chipset Family PMC
+	7aa3  600 Series Chipset Family SMBus
+	7aa4  600 Series Chipset Family SPI (flash) Controller
+	7aa6  600 Series Chipset Family Trace Hub
+	7aa7  600 Series Chipset Family Shared SRAM
+	7aa8  600 Series Chipset Family UART #0
+	7aa9  600 Series Chipset Family UART #1
+	7aaa  600 Series Chipset Family GSPI #0
+	7aab  600 Series Chipset Family GSPI #1
+	7ab0  600 Series Chipset Family PCIe Root Port #9
+	7ab1  600 Series Chipset Family PCIe Root Port #10
+	7ab2  600 Series Chipset Family PCIe Root Port #11
+	7ab3  600 Series Chipset Family PCIe Root Port #12
+	7ab4  600 Series Chipset Family PCIe Root Port #13
+	7ab5  600 Series Chipset Family PCIe Root Port #14
+	7ab6  600 Series Chipset Family PCIe Root Port #15
+	7ab7  600 Series Chipset Family PCIe Root Port #16
+	7ab8  600 Series Chipset Family PCIe Root Port #1
+	7ab9  600 Series Chipset Family PCIe Root Port #2
+	7aba  600 Series Chipset Family PCIe Root Port #3
+	7abb  600 Series Chipset Family PCIe Root Port #4
+	7abc  600 Series Chipset Family PCIe Root Port #5
+	7abd  600 Series Chipset Family PCIe Root Port #6
+	7abe  600 Series Chipset Family PCIe Root Port #7
+	7abf  600 Series Chipset Family PCIe Root Port #8
+	7ac0  600 Series Chipset Family PCIe Root Port #17
+	7ac1  600 Series Chipset Family PCIe Root Port #18
+	7ac2  600 Series Chipset Family PCIe Root Port #19
+	7ac3  600 Series Chipset Family PCIe Root Port #20
+	7ac4  600 Series Chipset Family PCIe Root Port #21
+	7ac5  600 Series Chipset Family PCIe Root Port #22
+	7ac6  600 Series Chipset Family PCIe Root Port #23
+	7ac7  600 Series Chipset Family PCIe Root Port #24
+	7ac8  600 Series Chipset Family PCIe Root Port #25
+	7ac9  600 Series Chipset Family PCIe Root Port #26
+	7aca  600 Series Chipset Family PCIe Root Port #27
+	7acb  600 Series Chipset Family PCIe Root Port #28
+	7acc  600 Series Chipset Family I2C Controller #0
+	7acd  600 Series Chipset Family I2C Controller #1
+	7ace  600 Series Chipset Family I2C Controller #2
+	7acf  600 Series Chipset Family 12C Controller #3
+	7ad0  600 Series Chipset Family HD Audio
+	7ad1  600 Series Chipset Family HD Audio
+	7ad2  600 Series Chipset Family HD Audio
+	7ad3  600 Series Chipset Family HD Audio
+	7ad4  600 Series Chipset Family HD Audio
+	7ad5  600 Series Chipset Family HD Audio
+	7ad6  600 Series Chipset Family HD Audio
+	7ad7  600 Series Chipset Family HD Audio
+	7adc  600 Series Chipset Family UART #3
+	7ae0  600 Series Chipset Family USB 3.2 Gen 2x2 (20Gbs) XHCI Host Controller
+	7ae1  600 Series Chipset Family USB 3.2 Gen 1x1 (5Gbs) Device Controller (xDCI)
+	7ae2  600 Series Chipset Family SATA Controller (AHCI)
+	7ae8  600 Series Chipset Family CSME HECI #1
+	7ae9  600 Series Chipset Family CSME HECI #2
+	7aea  600 Series Chipset Family CSME IDE Redirection (IDE-R)
+	7aeb  600 Series Chipset Family CSME Keyboard and Text (KT) Redirection
+	7aec  600 Series Chipset Family CSME HECI #3
+	7aed  600 Series Chipset Family CSME HECI #4
+	7af0  600 Series Chipset Family CNVi Wi-Fi
 		8086 0034  Wireless-AC 9560
 		8086 0070  Wi-Fi 6 AX201 160MHz
 		8086 0094  Wi-Fi 6 AX201 160MHz
-	7af8  Alder Lake-S Integrated Sensor Hub
-	7afc  Alder Lake-S PCH Serial IO I2C Controller #4
-	7afd  Alder Lake-S PCH Serial IO I2C Controller #5
+	7af1  600 Series Chipset Family CNVi Wi-Fi
+	7af2  600 Series Chipset Family CNVi Wi-Fi
+	7af3  600 Series Chipset Family CNVi Wi-Fi
+	7af8  600 Series Chipset Family Integrated Sensor Hub
+	7af9  600 Series Chipset Family GSPI #3
+	7afb  600 Series Chipset Family GSPI #2
+	7afc  600 Series Chipset Family I2C Controller #4
+	7afd  600 Series Chipset Family I2C Controller #5
+	7afe  600 Series Chipset Family UART #2
 	7d01  Meteor Lake-H 6p+8e cores Host Bridge/DRAM Controller
 	7d03  Meteor Lake-P Dynamic Tuning Technology
 	7d06  Arrow Lake-H 6p+8e cores Host Bridge/DRAM Controller
 	7d0b  Volume Management Device NVMe RAID Controller Intel Corporation
 	7d0d  Meteor Lake-P Platform Monitoring Technology
 	7d19  Meteor Lake IPU
+	7d1a  Core Ultra 200S/200S-Plus Series Processors with 8 P-Cores 16 E-Cores Host Bridge
+	7d1b  Core Ultra 200S Series Processors with 8 P-Cores 12 E-Cores Host Bridge
 	7d1c  Arrow Lake-HX 8p+16e cores Host Bridge
 	7d1d  Meteor Lake NPU
+	7d29  Core Ultra 200S-Plus Series Processors with 6 P-Cores 12 E-Cores Host Bridge
+	7d2a  Core Ultra 200S Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d2d  Core Ultra 200HX/HX-Plus Series Processors with 8 P-Cores 12 E-Cores Host Bridge
+	7d2f  Core Ultra 200HX Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d30  Core Ultra 200U Series Processors with 2 P-Cores 8 E-Cores Host Bridge
+	7d35  Core Ultra 200S Series Processors with 6 P-Cores 4 E-Cores Host Bridge
 	7d40  Meteor Lake-M [Intel Graphics]
 	7d41  Arrow Lake-U [Intel Graphics]
 	7d45  Meteor Lake-P [Intel Graphics]
@@ -38928,43 +39457,93 @@
 	7e7e  Meteor Lake-P USB Device Controller
 	7e7f  Meteor Lake-H/U Shared SRAM
 	7ec0  Meteor Lake-P Thunderbolt 4 USB Controller
+	7ec1  Core Ultra 200 Series Processors USB xDCI
 	7ec2  Meteor Lake-P Thunderbolt 4 NHI #0
 	7ec3  Meteor Lake-P Thunderbolt 4 NHI #1
 	7ec4  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #0
 	7ec5  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1
 	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
 	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
-	7eca  Meteor Lake-H/U PCIe Root Port #10
-	7ecb  Arrow Lake-H/U PCIe Root Port #11 (PXPE)
-	7ecc  Meteor Lake-H PCIe Root Port #12
-	7f03  Q870 Chipset LPC/eSPI Controller
-	7f04  Z890 Chipset LPC/eSPI Controller
-	7f06  B860 Chipset LPC/eSPI Controller
-	7f07  H810 Chipset LPC/eSPI Controller
-	7f08  W880 Chipset LPC/eSPI Controller
-	7f0c  HM870 Chipset LPC/eSPI Controller
-	7f0d  WM880 Chipset LPC/eSPI Controller
-	7f20  800 Series PCH P2SB
-	7f21  800 Series PCH Power Management Controller
-	7f23  800 Series PCH SMBus Controller
-	7f24  800 Series PCH SPI (flash) Controller
-	7f27  800 Series PCH Shared SRAM
-	7f30  800 Series PCH PCIe Root Port #9
-	7f34  800 Series PCH PCIe Root Port #13
-	7f36  800 Series PCH PCIe Root Port #15
-	7f38  800 Series PCH PCIe Root Port #1
-	7f3e  800 Series PCH PCIe Root Port #7
-	7f40  800 Series PCH PCIe Root Port #17
-	7f44  800 Series PCH PCIe Root Port #21
-	7f4c  800 Series PCH I2C Controller #0
-	7f4f  800 Series PCH I2C Controller #3
-	7f50  800 Series ACE (Audio Context Engine)
-	7f68  800 Series PCH HECI #1
-	7f6e  800 Series PCH USB 3.1 xHCI HC
-	7f70  Arrow Lake-S PCH CNVi WiFi
+	7ec8  Core Ultra 200 Series Processors P2SB (IOE)
+	7ec9  Core Ultra 200H/200V Series Processors IEH (IOE)
+	7eca  Core Ultra 200 Series Processors PCIe Root Port #10
+	7ecb  Core Ultra 200H/200V Series Processors PCIe Root Port #11 (PXPE)
+	7ecc  Core Ultra 200 Series Processors PCIe Root Port #12
+	7ece  Core Ultra 200 Series Processors PMC (IOE)
+	7ecf  Core Ultra 200 Series Processors Shared SRAM (IOE)
+	7f03  Q870 Chipset eSPI Controller
+	7f04  Z890 Chipset eSPI Controller
+	7f06  B860 Chipset eSPI Controller
+	7f07  H810 Chipset eSPI Controller
+	7f08  W880 Chipset eSPI Controller
+	7f0c  HM870 Chipset eSPI Controller
+	7f0d  WM880 Chipset eSPI Controller
+	7f20  800 Series Chipset Family P2SB
+	7f21  800 Series Chipset Family PMC
+	7f23  800 Series Chipset Family SMBus
+	7f24  800 Series Chipset Family SPI (flash) Controller
+	7f26  800 Series Chipset Family Trace Hub
+	7f27  800 Series Chipset Family Shared SRAM
+	7f28  800 Series Chipset Family UART #0
+	7f29  800 Series Chipset Family UART #1
+	7f2a  800 Series Chipset Family GSPI #0
+	7f2b  800 Series Chipset Family GSPI #1
+	7f30  800 Series Chipset Family PCIe Root Port #9
+	7f31  800 Series Chipset Family PCIe Root Port #10
+	7f32  800 Series Chipset Family PCIe Root Port #11
+	7f33  800 Series Chipset Family PCIe Root Port #12
+	7f34  800 Series Chipset Family PCIe Root Port #13
+	7f35  800 Series Chipset Family PCIe Root Port #14
+	7f36  800 Series Chipset Family PCIe Root Port #15
+	7f37  800 Series Chipset Family PCIe Root Port #16
+	7f38  800 Series Chipset Family PCIe Root Port #1
+	7f39  800 Series Chipset Family PCIe Root Port #2
+	7f3a  800 Series Chipset Family PCIe Root Port #3
+	7f3b  800 Series Chipset Family PCIe Root Port #4
+	7f3c  800 Series Chipset Family PCIe Root Port #5
+	7f3d  800 Series Chipset Family PCIe Root Port #6
+	7f3e  800 Series Chipset Family PCIe Root Port #7
+	7f3f  800 Series Chipset Family PCIe Root Port #8
+	7f40  800 Series Chipset Family PCIe Root Port #17
+	7f41  800 Series Chipset Family PCIe Root Port #18
+	7f42  800 Series Chipset Family PCIe Root Port #19
+	7f43  800 Series Chipset Family PCIe Root Port #20
+	7f44  800 Series Chipset Family PCIe Root Port #21
+	7f45  800 Series Chipset Family PCIe Root Port #22
+	7f46  800 Series Chipset Family PCIe Root Port #23
+	7f47  800 Series Chipset Family PCIe Root Port #24
+	7f4c  800 Series Chipset Family I2C #0
+	7f4d  800 Series Chipset Family I2C #1
+	7f4e  800 Series Chipset Family I2C #2
+	7f4f  800 Series Chipset Family I2C #3
+	7f50  800 Series Chipset Family Audio Context Engine (ACE)
+	7f58  800 Series Chipset Family Touch Host Controller (THC) #0 ID1
+	7f59  800 Series Chipset Family Touch Host Controller (THC) #0 ID2
+	7f5a  800 Series Chipset Family Touch Host Controller (THC) #1 ID1
+	7f5b  800 Series Chipset Family Touch Host Controller (THC) #1 ID2
+	7f5c  800 Series Chipset Family UART #2
+	7f5d  800 Series Chipset Family UART #3
+	7f5e  800 Series Chipset Family GSPI #2
+	7f5f  800 Series Chipset Family GSPI #3
+	7f62  800 Series Chipset Family SATA Controller (AHCI)
+	7f66  800 Series Chipset Family SATA Controller (RAID 0/1/5/10) premium
+	7f68  800 Series Chipset Family CSME HECI #1
+	7f69  800 Series Chipset Family CSME HECI #2
+	7f6a  800 Series Chipset Family IDE Redirection (IDER-R)
+	7f6b  800 Series Chipset Family Keyboard and Text (KT) Redirection
+	7f6c  800 Series Chipset Family CSME HECI #3
+	7f6d  800 Series Chipset Family CSME HECI #4
+	7f6e  800 Series Chipset Family USB 3.1 xHCI HC
+	7f6f  800 Series Chipset Family USB Device Controller (OTG) (xDCI)
+	7f70  800 Series Chipset Family CNVi Wi-Fi
 		8086 0094  WiFi 6E AX211 160MHz
-	7f7a  800 Series PCH I2C Controller #4
-	7f7b  800 Series PCH I2C Controller #5
+	7f78  800 Series Chipset Family Integrated Sensor Hub
+	7f79  800 Series Chipset Family I3C
+	7f7a  800 Series Chipset Family I2C #4
+	7f7b  800 Series Chipset Family I2C #5
+	7f7c  800 Series Chipset Family Silicon Security Engine HECI #1
+	7f7d  800 Series Chipset Family Silicon Security Engine HECI #2
+	7f7e  800 Series Chipset Family Silicon Security Engine HECI #3
 	8002  Trusted Execution Technology Registers
 	8003  Trusted Execution Technology Registers
 	8100  US15W/US15X SCH [Poulsbo] Host Bridge
@@ -39762,65 +40341,65 @@
 	a106  Q170/H170/Z170/CM236 Chipset SATA Controller [RAID Mode]
 	a107  HM170/QM170 Chipset SATA Controller [RAID Mode]
 	a10f  Sunrise Point-H SATA Controller [RAID mode]
-	a110  100 Series/C230 Series Chipset Family PCI Express Root Port #1
-	a111  100 Series/C230 Series Chipset Family PCI Express Root Port #2
-	a112  100 Series/C230 Series Chipset Family PCI Express Root Port #3
-	a113  100 Series/C230 Series Chipset Family PCI Express Root Port #4
-	a114  100 Series/C230 Series Chipset Family PCI Express Root Port #5
+	a110  100/C230 Series Chipset Family PCIe Root Port #1
+	a111  100/C230 Series Chipset Family PCIe Root Port #2
+	a112  100/C230 Series Chipset Family PCIe Root Port #3
+	a113  100/C230 Series Chipset Family PCIe Root Port #4
+	a114  100/C230 Series Chipset Family PCIe Root Port #5
 		1043 8694  H110I-PLUS Motherboard
-	a115  100 Series/C230 Series Chipset Family PCI Express Root Port #6
-	a116  100 Series/C230 Series Chipset Family PCI Express Root Port #7
-	a117  100 Series/C230 Series Chipset Family PCI Express Root Port #8
-	a118  100 Series/C230 Series Chipset Family PCI Express Root Port #9
+	a115  100/C230 Series Chipset Family PCIe Root Port #6
+	a116  100/C230 Series Chipset Family PCIe Root Port #7
+	a117  100/C230 Series Chipset Family PCIe Root Port #8
+	a118  100/C230 Series Chipset Family PCIe Root Port #9
 		1043 8694  H110I-PLUS Motherboard
-	a119  100 Series/C230 Series Chipset Family PCI Express Root Port #10
+	a119  100/C230 Series Chipset Family PCIe Root Port #10
 		1043 8694  H110I-PLUS Motherboard
-	a11a  100 Series/C230 Series Chipset Family PCI Express Root Port #11
-	a11b  100 Series/C230 Series Chipset Family PCI Express Root Port #12
-	a11c  100 Series/C230 Series Chipset Family PCI Express Root Port #13
-	a11d  100 Series/C230 Series Chipset Family PCI Express Root Port #14
-	a11e  100 Series/C230 Series Chipset Family PCI Express Root Port #15
-	a11f  100 Series/C230 Series Chipset Family PCI Express Root Port #16
-	a120  100 Series/C230 Series Chipset Family P2SB
-	a121  100 Series/C230 Series Chipset Family Power Management Controller
+	a11a  100/C230 Series Chipset Family PCIe Root Port #11
+	a11b  100/C230 Series Chipset Family PCIe Root Port #12
+	a11c  100/C230 Series Chipset Family PCIe Root Port #13
+	a11d  100/C230 Series Chipset Family PCIe Root Port #14
+	a11e  100/C230 Series Chipset Family PCIe Root Port #15
+	a11f  100/C230 Series Chipset Family PCIe Root Port #16
+	a120  100/C230 Series Chipset Family P2SB
+	a121  100/C230 Series Chipset Family PMC
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
 	a122  Sunrise Point-H cAVS
-	a123  100 Series/C230 Series Chipset Family SMBus
+	a123  100/C230 Series Chipset Family SMBus
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a124  100 Series/C230 Series Chipset Family SPI Controller
-	a125  100 Series/C230 Series Chipset Family Gigabit Ethernet Controller
-	a126  100 Series/C230 Series Chipset Family Trace Hub
-	a127  100 Series/C230 Series Chipset Family Serial IO UART #0
-	a128  100 Series/C230 Series Chipset Family Serial IO UART #1
-	a129  100 Series/C230 Series Chipset Family Serial IO GSPI #0
-	a12a  100 Series/C230 Series Chipset Family Serial IO GSPI #1
-	a12f  100 Series/C230 Series Chipset Family USB 3.0 xHCI Controller
+	a124  100/C230 Series Chipset Family SPI Controller
+	a125  100/C230 Series Chipset Family GbE Controller
+	a126  100/C230 Series Chipset Family Trace Hub
+	a127  100/C230 Series Chipset Family UART #0
+	a128  100/C230 Series Chipset Family UART #1
+	a129  100/C230 Series Chipset Family GSPI #0
+	a12a  100/C230 Series Chipset Family GSPI #1
+	a12f  100/C230 Series Chipset Family USB 3.0 xHCI Controller
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a130  100 Series/C230 Series Chipset Family USB Device Controller (OTG)
-	a131  100 Series/C230 Series Chipset Family Thermal Subsystem
+	a130  100/C230 Series Chipset Family USB Device Controller (OTG)
+	a131  100/C230 Series Chipset Family Thermal Subsystem
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1462 7994  H110M ECO/GAMING
 	a133  Sunrise Point-H Northpeak ACPI Function
-	a135  100 Series/C230 Series Chipset Family Integrated Sensor Hub
-	a13a  100 Series/C230 Series Chipset Family MEI Controller #1
+	a135  100/C230 Series Chipset Family ISH
+	a13a  100/C230 Series Chipset Family MEI #1
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 8694  H110I-PLUS Motherboard
 		1462 7994  H110M ECO/GAMING
-	a13b  100 Series/C230 Series Chipset Family MEI Controller #2
-	a13c  100 Series/C230 Series Chipset Family IDE Redirection
-	a13d  100 Series/C230 Series Chipset Family KT Redirection
-	a13e  100 Series/C230 Series Chipset Family MEI Controller #3
+	a13b  100/C230 Series Chipset Family MEI #2
+	a13c  100/C230 Series Chipset Family IDE Redirection
+	a13d  100/C230 Series Chipset Family Keyboard and Text (KT) Redirection
+	a13e  100/C230 Series Chipset Family MEI #3
 	a140  Sunrise Point-H LPC Controller
 	a141  Sunrise Point-H LPC Controller
 	a142  Sunrise Point-H LPC Controller
@@ -39857,44 +40436,44 @@
 	a15d  Sunrise Point-H LPC Controller
 	a15e  Sunrise Point-H LPC Controller
 	a15f  Sunrise Point-H LPC Controller
-	a160  100 Series/C230 Series Chipset Family Serial IO I2C Controller #0
+	a160  100/C230 Series Chipset Family I2C #0
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
-	a161  100 Series/C230 Series Chipset Family Serial IO I2C Controller #1
+	a161  100/C230 Series Chipset Family I2C #1
 		1028 06e4  XPS 15 9550
-	a162  100 Series/C230 Series Chipset Family Serial IO I2C Controller #2
-	a163  100 Series/C230 Series Chipset Family Serial IO I2C Controller #3
-	a166  100 Series/C230 Series Chipset Family Serial IO UART Controller #2
-	a167  100 Series/C230 Series Chipset Family PCI Express Root Port #17
-	a168  100 Series/C230 Series Chipset Family PCI Express Root Port #18
-	a169  100 Series/C230 Series Chipset Family PCI Express Root Port #19
-	a16a  100 Series/C230 Series Chipset Family PCI Express Root Port #20
-	a170  100 Series/C230 Series Chipset Family HD Audio Controller
+	a162  100/C230 Series Chipset Family I2C #2
+	a163  100/C230 Series Chipset Family I2C #3
+	a166  100/C230 Series Chipset Family UART #2
+	a167  100/C230 Series Chipset Family PCIe Root Port #17
+	a168  100/C230 Series Chipset Family PCIe Root Port #18
+	a169  100/C230 Series Chipset Family PCIe Root Port #19
+	a16a  100/C230 Series Chipset Family PCIe Root Port #20
+	a170  100/C230 Series Chipset Family HD Audio
 		1028 06e4  XPS 15 9550
 		103c 825b  OMEN-17-w001nv
 		1043 86c7  H110I-PLUS Motherboard
 		1462 f994  H110M ECO/GAMING
 	a171  HM175/QM175/CM238 HD Audio Controller
-	a182  C620 Series Chipset Family SATA Controller [AHCI mode]
-	a186  C620 Series Chipset Family SATA Controller [RAID mode]
-	a190  C620 Series Chipset Family PCI Express Root Port #1
-	a191  C620 Series Chipset Family PCI Express Root Port #2
-	a192  C620 Series Chipset Family PCI Express Root Port #3
-	a193  C620 Series Chipset Family PCI Express Root Port #4
-	a194  C620 Series Chipset Family PCI Express Root Port #5
-	a195  C620 Series Chipset Family PCI Express Root Port #6
-	a196  C620 Series Chipset Family PCI Express Root Port #7
-	a197  C620 Series Chipset Family PCI Express Root Port #8
-	a198  C620 Series Chipset Family PCI Express Root Port #9
-	a199  C620 Series Chipset Family PCI Express Root Port #10
-	a19a  C620 Series Chipset Family PCI Express Root Port #11
-	a19b  C620 Series Chipset Family PCI Express Root Port #12
-	a19c  C620 Series Chipset Family PCI Express Root Port #13
-	a19d  C620 Series Chipset Family PCI Express Root Port #14
-	a19e  C620 Series Chipset Family PCI Express Root Port #15
-	a19f  C620 Series Chipset Family PCI Express Root Port #16
+	a182  C620 Series Chipset Family SATA Controller (AHCI)
+	a186  C620 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a190  C620 Series Chipset Family PCIe Root Port #0
+	a191  C620 Series Chipset Family PCIe Root Port #1
+	a192  C620 Series Chipset Family PCIe Root Port #2
+	a193  C620 Series Chipset Family PCIe Root Port #3
+	a194  C620 Series Chipset Family PCIe Root Port #4
+	a195  C620 Series Chipset Family PCIe Root Port #5
+	a196  C620 Series Chipset Family PCIe Root Port #6
+	a197  C620 Series Chipset Family PCIe Root Port #7
+	a198  C620 Series Chipset Family PCIe Root Port #8
+	a199  C620 Series Chipset Family PCIe Root Port #9
+	a19a  C620 Series Chipset Family PCIe Root Port #10
+	a19b  C620 Series Chipset Family PCIe Root Port #11
+	a19c  C620 Series Chipset Family PCIe Root Port #12
+	a19d  C620 Series Chipset Family PCIe Root Port #13
+	a19e  C620 Series Chipset Family PCIe Root Port #14
+	a19f  C620 Series Chipset Family PCIe Root Port #15
 	a1a0  C620 Series Chipset Family P2SB
-	a1a1  C620 Series Chipset Family Power Management Controller
+	a1a1  C620 Series Chipset Family PMC
 		15d9 095d  X11SPM-TF
 	a1a2  C620 Series Chipset Family cAVS
 	a1a3  C620 Series Chipset Family SMBus
@@ -39906,131 +40485,155 @@
 		15d9 095d  X11SPM-TF
 	a1b1  C620 Series Chipset Family Thermal Subsystem
 		15d9 095d  X11SPM-TF
-	a1ba  C620 Series Chipset Family MEI Controller #1
+	a1ba  C620 Series Chipset Family MEI HECI #1
 		15d9 095d  X11SPM-TF
-	a1bb  C620 Series Chipset Family MEI Controller #2
+	a1bb  C620 Series Chipset Family MEI HECI #2
 		15d9 095d  X11SPM-TF
-	a1bc  C620 Series Chipset Family IDE Redirection
-	a1bd  C620 Series Chipset Family KT Redirection
-	a1be  C620 Series Chipset Family MEI Controller #3
+	a1bc  C620 Series Chipset Family MEI IDE Redirection
+	a1bd  C620 Series Chipset Family MEI Keyboard and Text (KT) Redirection
+	a1be  C620 Series Chipset Family MEI HECI #3
 		15d9 095d  X11SPM-TF
-	a1c1  C621 Series Chipset LPC/eSPI Controller
-	a1c2  C622 Series Chipset LPC/eSPI Controller
+	a1c1  C621 Chipset LPC/eSPI Controller
+	a1c2  C622 Chipset LPC/eSPI Controller
 		15d9 095d  X11SPM-TF
-	a1c3  C624 Series Chipset LPC/eSPI Controller
-	a1c4  C625 Series Chipset LPC/eSPI Controller
-	a1c5  C626 Series Chipset LPC/eSPI Controller
-	a1c6  C627 Series Chipset LPC/eSPI Controller
-	a1c7  C628 Series Chipset LPC/eSPI Controller
-	a1d2  C620 Series Chipset Family SSATA Controller [AHCI mode]
-	a1d6  C620 Series Chipset Family SSATA Controller [RAID mode]
-	a1e7  C620 Series Chipset Family PCI Express Root Port #17
-	a1e8  C620 Series Chipset Family PCI Express Root Port #18
-	a1e9  C620 Series Chipset Family PCI Express Root Port #19
-	a1ea  C620 Series Chipset Family PCI Express Root Port #20
+	a1c3  C624 Chipset LPC/eSPI Controller
+	a1c4  C625 Chipset LPC/eSPI Controller
+	a1c5  C626 Chipset LPC/eSPI Controller
+	a1c6  C627 Chipset LPC/eSPI Controller
+	a1c7  C628 Chipset LPC/eSPI Controller
+	a1ca  C629 Chipset LPC/eSPI Controller
+	a1d2  C620 Series Chipset Family SSATA Controller (AHCI)
+	a1d6  C620 Series Chipset Family SSATA Controller (RAID 0/1/5/10)
+	a1e7  C620 Series Chipset Family PCIe Root Port #16
+	a1e8  C620 Series Chipset Family PCIe Root Port #17
+	a1e9  C620 Series Chipset Family PCIe Root Port #18
+	a1ea  C620 Series Chipset Family PCIe Root Port #19
 	a1ec  C620 Series Chipset Family MROM 0
 	a1ed  C620 Series Chipset Family MROM 1
-	a1f0  C62x HD Audio Controller
-	a1f8  Lewisburg IE: HECI #1
-	a1f9  Lewisburg IE: HECI #2
-	a1fa  Lewisburg IE: IDE-r
-	a1fb  Lewisburg IE: KT Controller
-	a1fc  Lewisburg IE: HECI #3
-	a202  Lewisburg SATA Controller [AHCI mode]
-	a206  Lewisburg SATA Controller [RAID mode]
-	a210  Lewisburg PCI Express Root Port
-	a211  Lewisburg PCI Express Root Port
-	a212  Lewisburg PCI Express Root Port
-	a213  Lewisburg PCI Express Root Port
-	a214  Lewisburg PCI Express Root Port
-	a215  Lewisburg PCI Express Root Port
-	a216  Lewisburg PCI Express Root Port
-	a217  Lewisburg PCI Express Root Port
-	a218  Lewisburg PCI Express Root Port
-	a219  Lewisburg PCI Express Root Port
-	a21a  Lewisburg PCI Express Root Port
-	a21b  Lewisburg PCI Express Root Port
-	a21c  Lewisburg PCI Express Root Port
-	a21d  Lewisburg PCI Express Root Port
-	a21e  Lewisburg PCI Express Root Port
-	a21f  Lewisburg PCI Express Root Port
-	a221  Lewisburg Power Management Controller
-	a223  Lewisburg SMBus
-	a224  Lewisburg SPI Controller
-	a242  Lewisburg LPC or eSPI Controller
-	a243  Lewisburg LPC or eSPI Controller
-	a252  Lewisburg SSATA Controller [AHCI mode]
-	a256  Lewisburg SSATA Controller [RAID mode]
-	a267  Lewisburg PCI Express Root Port
-	a268  Lewisburg PCI Express Root Port
-	a269  Lewisburg PCI Express Root Port
-	a26a  Lewisburg PCI Express Root Port
-	a282  200 Series PCH SATA controller [AHCI mode]
+	a1f0  C620 Series Chipset Family HD Audio
+	a1f8  C620 Series Chipset Family IE HECI #1
+	a1f9  C620 Series Chipset Family IE HECI #2
+	a1fa  C620 Series Chipset Family IE IDE Redirection
+	a1fb  C620 Series Chipset Family IE Keyboard and Text Redirection
+	a1fc  C620 Series Chipset Family IE HECI #3
+	a202  C620 Series Chipset Family (Super) SATA Controller (AHCI)
+	a206  C620 Series Chipset Family (Super) SATA Controller (RAID 0/1/5/10)
+	a210  C620 Series Chipset Family (Super) PCIe Root Port #0
+	a211  C620 Series Chipset Family (Super) PCIe Root Port #1
+	a212  C620 Series Chipset Family (Super) PCIe Root Port #2
+	a213  C620 Series Chipset Family (Super) PCIe Root Port #3
+	a214  C620 Series Chipset Family (Super) PCIe Root Port #4
+	a215  C620 Series Chipset Family (Super) PCIe Root Port #5
+	a216  C620 Series Chipset Family (Super) PCIe Root Port #6
+	a217  C620 Series Chipset Family (Super) PCIe Root Port #7
+	a218  C620 Series Chipset Family (Super) PCIe Root Port #8
+	a219  C620 Series Chipset Family (Super) PCIe Root Port #9
+	a21a  C620 Series Chipset Family (Super) PCIe Root Port #10
+	a21b  C620 Series Chipset Family (Super) PCIe Root Port #11
+	a21c  C620 Series Chipset Family (Super) PCIe Root Port #12
+	a21d  C620 Series Chipset Family (Super) PCIe Root Port #13
+	a21e  C620 Series Chipset Family (Super) PCIe Root Port #14
+	a21f  C620 Series Chipset Family (Super) PCIe Root Port #15
+	a220  C620 Series Chipset Family (Super) P2SB
+	a221  C620 Series Chipset Family (Super) PMC
+	a223  C620 Series Chipset Family (Super) SMBus
+	a224  C620 Series Chipset Family (Super) SPI Controller
+	a226  C620 Series Chipset Family (Super) Trace Hub
+	a22f  C620 Series Chipset Family (Super) USB 3.0 xHCI Controller
+	a231  C620 Series Chipset Family (Super) Thermal Subsystem
+	a23a  C620 Series Chipset Family (Super) MEI HECI #1
+	a23b  C620 Series Chipset Family (Super) MEI HECI #2
+	a23c  C620 Series Chipset Family (Super) MEI IDE Redirection
+	a23d  C620 Series Chipset Family (Super) MEI Keyboard and Text (KT) Redirection
+	a23e  C620 Series Chipset Family (Super) MEI HECI #3
+	a242  C624 Chipset (Super) LPC/eSPI Controller
+	a243  C627 Chipset (Super) LPC/eSPI Controller
+	a244  C621 Chipset (Super) LPC/eSPI Controller
+	a245  C627 Chipset (Super) LPC/eSPI Controller
+	a246  C628 Chipset (Super) LPC/eSPI Controller
+	a252  C620 Series Chipset Family (Super) SSATA Controller (AHCI)
+	a256  C620 Series Chipset Family (Super) SSATA Controller (RAID 0/1/5/10)
+	a267  C620 Series Chipset Family (Super) PCIe Root Port #16
+	a268  C620 Series Chipset Family (Super) PCIe Root Port #17
+	a269  C620 Series Chipset Family (Super) PCIe Root Port #18
+	a26a  C620 Series Chipset Family (Super) PCIe Root Port #19
+	a26c  C620 Series Chipset Family (Super) MROM 0
+	a270  C620 Series Chipset Family (Super) Audio
+	a278  C620 Series Chipset Family (Super) IE HECI #1
+	a279  C620 Series Chipset Family (Super) IE HECI #2
+	a27a  C620 Series Chipset Family (Super) IE IDE Redirection
+	a27b  C620 Series Chipset Family (Super) IE Keyboard and Text Redirection
+	a27c  C620 Series Chipset Family (Super) IE HECI #3
+	a282  200 Series/Z370 Chipset Family SATA Controller (AHCI)
 		1462 7a72  H270 PC MATE
-	a286  200 Series PCH SATA controller [RAID mode]
-	a290  200 Series PCH PCI Express Root Port #1
-	a291  200 Series PCH PCI Express Root Port #2
-	a292  200 Series PCH PCI Express Root Port #3
-	a293  200 Series PCH PCI Express Root Port #4
-	a294  200 Series PCH PCI Express Root Port #5
+	a286  200 Series/Z370 Chipset Family SATA Controller (RAID) Premium
+	a28e  200 Series/Z370 Chipset Family SATA Controller (RST and Optane Technology)
+	a290  200 Series/Z370 Chipset Family PCIe Root Port #1
+	a291  200 Series/Z370 Chipset Family PCIe Root Port #2
+	a292  200 Series/Z370 Chipset Family PCIe Root Port #3
+	a293  200 Series/Z370 Chipset Family PCIe Root Port #4
+	a294  200 Series/Z370 Chipset Family PCIe Root Port #5
 		1462 7a72  H270 PC MATE
-	a295  200 Series PCH PCI Express Root Port #6
-	a296  200 Series PCH PCI Express Root Port #7
+	a295  200 Series/Z370 Chipset Family PCIe Root Port #6
+	a296  200 Series/Z370 Chipset Family PCIe Root Port #7
 		1462 7a72  H270 PC MATE
-	a297  200 Series PCH PCI Express Root Port #8
-	a298  200 Series PCH PCI Express Root Port #9
+	a297  200 Series/Z370 Chipset Family PCIe Root Port #8
+	a298  200 Series/Z370 Chipset Family PCIe Root Port #9
 		1462 7a72  H270 PC MATE
-	a299  200 Series PCH PCI Express Root Port #10
-	a29a  200 Series PCH PCI Express Root Port #11
-	a29b  200 Series PCH PCI Express Root Port #12
-	a29c  200 Series PCH PCI Express Root Port #13
-	a29d  200 Series PCH PCI Express Root Port #14
-	a29e  200 Series PCH PCI Express Root Port #15
-	a29f  200 Series PCH PCI Express Root Port #16
+	a299  200 Series/Z370 Chipset Family PCIe Root Port #10
+	a29a  200 Series/Z370 Chipset Family PCIe Root Port #11
+	a29b  200 Series/Z370 Chipset Family PCIe Root Port #12
+	a29c  200 Series/Z370 Chipset Family PCIe Root Port #13
+	a29d  200 Series/Z370 Chipset Family PCIe Root Port #14
+	a29e  200 Series/Z370 Chipset Family PCIe Root Port #15
+	a29f  200 Series/Z370 Chipset Family PCIe Root Port #16
 	a2a0  200 Series/Z370 Chipset Family P2SB
-	a2a1  200 Series/Z370 Chipset Family Power Management Controller
+	a2a1  200 Series/Z370 Chipset Family PMC
 		1462 7a72  H270 PC MATE
-	a2a3  200 Series/Z370 Chipset Family SMBus Controller
+	a2a3  200 Series/Z370 Chipset Family SMBus
 		1462 7a72  H270 PC MATE
 	a2a4  200 Series/Z370 Chipset Family SPI Controller
-	a2a5  200 Series/Z370 Chipset Family Gigabit Ethernet Controller
+	a2a5  200 Series/Z370 Chipset Family GbE Controller
 	a2a6  200 Series/Z370 Chipset Family Trace Hub
-	a2a7  200 Series/Z370 Chipset Family Serial IO UART Controller #0
-	a2a8  200 Series/Z370 Chipset Family Serial IO UART Controller #1
-	a2a9  200 Series/Z370 Chipset Family Serial IO SPI Controller #0
-	a2aa  200 Series/Z370 Chipset Family Serial IO SPI Controller #1
+	a2a7  200 Series/Z370 Chipset Family UART #0
+	a2a8  200 Series/Z370 Chipset Family UART #1
+	a2a9  200 Series/Z370 Chipset Family GSPI #0
+	a2aa  200 Series/Z370 Chipset Family GSPI #1
 	a2af  200 Series/Z370 Chipset Family USB 3.0 xHCI Controller
 		1462 7a72  H270 PC MATE
-	a2b1  200 Series PCH Thermal Subsystem
+	a2b0  200 Series/Z370 Chipset Family USB Device Controller (OTG)
+	a2b1  200 Series/Z370 Chipset Family Thermal Subsystem
 		1462 7a72  H270 PC MATE
-	a2ba  200 Series PCH CSME HECI #1
+	a2b5  200 Series/Z370 Chipset Family ISH
+	a2ba  200 Series/Z370 Chipset Family MEI #1
 		1462 7a72  H270 PC MATE
-	a2bb  200 Series PCH CSME HECI #2
-# AMT serial over LAN
-	a2bd  200 Series Chipset Family KT Redirection
-	a2c4  200 Series PCH LPC Controller (H270)
+	a2bb  200 Series/Z370 Chipset Family MEI #2
+	a2bc  200 Series/Z370 Chipset Family IDE Redirection
+	a2bd  200 Series/Z370 Chipset Family Keyboard and Text (KT) Redirection
+	a2be  200 Series/Z370 Chipset Family MEI #3
+	a2c4  H270 Chipset LPC/eSPI Controller
 		1462 7a72  H270 PC MATE
-	a2c5  200 Series PCH LPC Controller (Z270)
-	a2c6  200 Series PCH LPC Controller (Q270)
-	a2c7  200 Series PCH LPC Controller (Q250)
-	a2c8  200 Series PCH LPC Controller (B250)
+	a2c5  Z270 Chipset LPC/eSPI Controller
+	a2c6  Q270 Chipset LPC/eSPI Controller
+	a2c7  Q250 Chipset LPC/eSPI Controller
+	a2c8  B250 Chipset LPC/eSPI Controller
 	a2c9  Z370 Chipset LPC/eSPI Controller
 	a2d2  X299 Chipset LPC/eSPI Controller
 	a2d3  C422 Chipset LPC/eSPI Controller
-	a2e0  200 Series PCH Serial IO I2C Controller #0
-	a2e1  200 Series PCH Serial IO I2C Controller #1
-	a2e2  200 Series PCH Serial IO I2C Controller #2
-	a2e3  200 Series PCH Serial IO I2C Controller #3
-	a2e6  200 Series PCH Serial IO UART Controller #2
-	a2e7  200 Series PCH PCI Express Root Port #17
-	a2e8  200 Series PCH PCI Express Root Port #18
-	a2e9  200 Series PCH PCI Express Root Port #19
-	a2ea  200 Series PCH PCI Express Root Port #20
-	a2eb  200 Series PCH PCI Express Root Port #21
-	a2ec  200 Series PCH PCI Express Root Port #22
-	a2ed  200 Series PCH PCI Express Root Port #23
-	a2ee  200 Series PCH PCI Express Root Port #24
-	a2f0  200 Series PCH HD Audio
+	a2e0  200 Series/Z370 Chipset Family I2C #0
+	a2e1  200 Series/Z370 Chipset Family I2C #1
+	a2e2  200 Series/Z370 Chipset Family I2C #2
+	a2e3  200 Series/Z370 Chipset Family I2C #3
+	a2e6  200 Series/Z370 Chipset Family UART #2
+	a2e7  200 Series/Z370 Chipset Family PCIe Root Port #17
+	a2e8  200 Series/Z370 Chipset Family PCIe Root Port #18
+	a2e9  200 Series/Z370 Chipset Family PCIe Root Port #19
+	a2ea  200 Series/Z370 Chipset Family PCIe Root Port #20
+	a2eb  200 Series/Z370 Chipset Family PCIe Root Port #21
+	a2ec  200 Series/Z370 Chipset Family PCIe Root Port #22
+	a2ed  200 Series/Z370 Chipset Family PCIe Root Port #23
+	a2ee  200 Series/Z370 Chipset Family PCIe Root Port #24
+	a2f0  200 Series/Z370 Chipset Family HD Audio
 		1462 7a72  H270 PC MATE
 		1462 fa72  H270 PC MATE
 	a303  H310 Chipset LPC/eSPI Controller
@@ -40046,57 +40649,76 @@
 	a30d  HM370 Chipset LPC/eSPI Controller
 	a30e  CM246 Chipset LPC/eSPI Controller
 	a313  Cannon Lake LPC/eSPI Controller
-	a323  Cannon Lake PCH SMBus Controller
+	a320  300/C240 Series Chipset Family P2SB
+	a321  300/C240 Series Chipset Family PMC
+	a323  300/C240 Series Chipset Family SMBus
 		1028 0869  Vostro 3470
-	a324  Cannon Lake PCH SPI Controller
+	a324  300/C240 Series Chipset Family SPI (Flash) Controller
 		1028 0869  Vostro 3470
-	a328  Cannon Lake PCH Serial IO UART Host Controller
-	a32b  Cannon Lake PCH SPI Host Controller
-	a32c  Cannon Lake PCH PCI Express Root Port #21
-	a32d  Cannon Lake PCH PCI Express Root Port #22
-	a32e  Cannon Lake PCH PCI Express Root Port #23
-	a32f  Cannon Lake PCH PCI Express Root Port #24
-	a330  Cannon Lake PCH PCI Express Root Port #9
-	a331  Cannon Lake PCH PCI Express Root Port #10
-	a332  Cannon Lake PCH PCI Express Root Port #11
-	a333  Cannon Lake PCH PCI Express Root Port #12
-	a334  Cannon Lake PCH PCI Express Root Port #13
-	a335  Cannon Lake PCH PCI Express Root Port #14
-	a336  Cannon Lake PCH PCI Express Root Port #15
-	a337  Cannon Lake PCH PCI Express Root Port #16
-	a338  Cannon Lake PCH PCI Express Root Port #1
-	a339  Cannon Lake PCH PCI Express Root Port #2
-	a33a  Cannon Lake PCH PCI Express Root Port #3
-	a33b  Cannon Lake PCH PCI Express Root Port #4
-	a33c  Cannon Lake PCH PCI Express Root Port #5
-	a33d  Cannon Lake PCH PCI Express Root Port #6
-	a33e  Cannon Lake PCH PCI Express Root Port #7
-	a33f  Cannon Lake PCH PCI Express Root Port #8
-	a340  Cannon Lake PCH PCI Express Root Port #17
-	a341  Cannon Lake PCH PCI Express Root Port #18
-	a342  Cannon Lake PCH PCI Express Root Port #19
-	a343  Cannon Lake PCH PCI Express Root Port #20
-	a348  Cannon Lake PCH cAVS
+	a326  300/C240 Series Chipset Family Trace Hub
+	a328  300/C240 Series Chipset Family UART #0
+	a329  300/C240 Series Chipset Family UART #1
+	a32a  300/C240 Series Chipset Family GSPI #0
+	a32b  300/C240 Series Chipset Family GSPI #1
+	a32c  300/C240 Series Chipset Family PCIe Root Port #21
+	a32d  300/C240 Series Chipset Family PCIe Root Port #22
+	a32e  300/C240 Series Chipset Family PCIe Root Port #23
+	a32f  300/C240 Series Chipset Family PCIe Root Port #24
+	a330  300/C240 Series Chipset Family PCIe Root Port #9
+	a331  300/C240 Series Chipset Family PCIe Root Port #10
+	a332  300/C240 Series Chipset Family PCIe Root Port #11
+	a333  300/C240 Series Chipset Family PCIe Root Port #12
+	a334  300/C240 Series Chipset Family PCIe Root Port #13
+	a335  300/C240 Series Chipset Family PCIe Root Port #14
+	a336  300/C240 Series Chipset Family PCIe Root Port #15
+	a337  300/C240 Series Chipset Family PCIe Root Port #16
+	a338  300/C240 Series Chipset Family PCIe Root Port #1
+	a339  300/C240 Series Chipset Family PCIe Root Port #2
+	a33a  300/C240 Series Chipset Family PCIe Root Port #3
+	a33b  300/C240 Series Chipset Family PCIe Root Port #4
+	a33c  300/C240 Series Chipset Family PCIe Root Port #5
+	a33d  300/C240 Series Chipset Family PCIe Root Port #6
+	a33e  300/C240 Series Chipset Family PCIe Root Port #7
+	a33f  300/C240 Series Chipset Family PCIe Root Port #8
+	a340  300/C240 Series Chipset Family PCIe Root Port #17
+	a341  300/C240 Series Chipset Family PCIe Root Port #18
+	a342  300/C240 Series Chipset Family PCIe Root Port #19
+	a343  300/C240 Series Chipset Family PCIe Root Port #20
+	a347  300/C240 Series Chipset Family UART #2
+	a348  300/C240 Series Chipset Family HD Audio
 		1028 0869  Vostro 3470
-	a352  Cannon Lake PCH SATA AHCI Controller
+	a352  300/C240 Series Chipset Family SATA Controller (AHCI)
 		1028 0869  Vostro 3470
-	a353  Cannon Lake Mobile PCH SATA AHCI Controller
-	a360  Cannon Lake PCH HECI Controller
+	a353  300/C240 Series Chipset Family SATA Controller (AHCI)
+	a355  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a356  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a357  300/C240 Series Chipset Family SATA Controller (RAID 0/1/5/10)
+	a35e  300/C240 Series Chipset Family SATA Controller Optane Memory
+	a360  300/C240 Series Chipset Family HECI #1
 		1028 0869  Vostro 3470
-	a363  Cannon Lake PCH Active Management Technology - SOL
-	a364  Cannon Lake PCH HECI Controller #2
-	a368  Cannon Lake PCH Serial IO I2C Controller #0
-	a369  Cannon Lake PCH Serial IO I2C Controller #1
-	a36a  Cannon Lake PCH Serial IO I2C Controller #2
-	a36b  Cannon Lake PCH Serial IO I2C Controller #3
-	a36d  Cannon Lake PCH USB 3.1 xHCI Host Controller
+	a361  300/C240 Series Chipset Family HECI #2
+	a362  300/C240 Series Chipset Family IDE Redirection (IDER-R)
+	a363  300/C240 Series Chipset Family Keyboard and Text (KT) Redirection
+	a364  300/C240 Series Chipset Family HECI #3
+	a365  300/C240 Series Chipset Family HECI #4
+	a368  300/C240 Series Chipset Family I2C Controller #0
+	a369  300/C240 Series Chipset Family I2C Controller #1
+	a36a  300/C240 Series Chipset Family I2C Controller #2
+	a36b  300/C240 Series Chipset Family I2C Controller #3
+	a36d  300/C240 Series Chipset Family USB 3.1 xHCI
 		1028 0869  Vostro 3470
-	a36f  Cannon Lake PCH Shared SRAM
-	a370  Cannon Lake PCH CNVi WiFi
+	a36e  300/C240 Series Chipset Family USB Device Controller (Dual Role)
+	a36f  300/C240 Series Chipset Family Shared SRAM
+	a370  300/C240 Series Chipset Family CNVi Wi-Fi
 		1a56 1552  Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW)
 		8086 0034  Wireless-AC 9560
-	a379  Cannon Lake PCH Thermal Controller
+	a371  300/C240 Series Chipset Family CNVi Wi-Fi
+	a372  300/C240 Series Chipset Family CNVi Wi-Fi
+	a373  300/C240 Series Chipset Family CNVi Wi-Fi
+	a379  300/C240 Series Chipset Family Thermal Subsystem
 		1028 0869  Vostro 3470
+	a37b  300/C240 Series Chipset Family SPI #2
+	a37c  300/C240 Series Chipset Family Integrated Sensor Hub
 	a382  400 Series Chipset Family SATA AHCI Controller
 	a394  Comet Lake PCI Express Root Port #05
 	a397  Comet Lake PCI Express Root Port #08
@@ -40496,6 +41118,7 @@
 		8510 0013  GB02-PCIe-C25-HH
 		8510 0014  GB2064-VPX-V40
 		8510 0201  GB2062-PUB-DDR
+	0301  GenBu03 Series GPU
 # nee ScaleMP
 8686  SAP
 	1010  vSMP Foundation controller [vSMP CTL]


### PR DESCRIPTION
Automated monthly update of hardware IDs to version 0.408

## Updated Files
- PCI IDs: 2026-06-01
- USB IDs: 2025-12-13
- Vendor IDs (OUI/IAB/PNP): Updated

## PCI Changes
```
old vendor count: 2500
new vendor count: 2502
vendors added:    2
vendors removed:  0
vendors renamed:  1
devices added:    399
devices removed:  2
devices renamed:  502
```

## Testing
- [x] `make check` passes
- [x] Packit builds successful
- [x] Tests pass on all targets

🤖 Generated by monthly-update.py automation

## Summary by Sourcery

Update hwdata to release 0.408 with refreshed hardware identification data files.

Enhancements:
- Refresh PCI and vendor ID databases (including OUI/IAB/PNP data) to the latest upstream snapshot.

Build:
- Bump RPM spec version and changelog entry for the 0.408-1 release of hwdata.