### PR TITLE
Monthly update - July 2026

### DIFF
--- a/hwdata.spec
+++ b/hwdata.spec
@@ -1,6 +1,6 @@
 Name: hwdata
 Summary: Hardware identification and configuration data
-Version: 0.408
+Version: 0.409
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 Source: https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
@@ -42,6 +42,9 @@ The %{name}-devel package contains files for developing applications that use
 %{_datadir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Jul 02 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.409-1
+- Update pci, usb, vendor ids
+
 * Mon Jun 01 2026 Vitezslav Crhonek <vcrhonek@redhat.com> - 0.408-1
 - Update pci, vendor ids
 

--- a/pci.ids
+++ b/pci.ids
@@ -1,8 +1,8 @@
 #
 #	List of PCI IDs
 #
-#	Version: 2026.06.01
-#	Date:    2026-06-01 03:15:02
+#	Version: 2026.07.01
+#	Date:    2026-07-01 03:15:02
 #
 #	Maintained by Albert Pool, Martin Mares, and other volunteers from
 #	the PCI ID Project at https://pci-ids.ucw.cz/.
@@ -73,7 +73,7 @@
 	7a34  2K2000/3000 / 3B6000M / 7A2000 Chipset USB 3.0 xHCI Controller
 	7a35  LG200 GPU
 	7a36  2K2000 / 7A2000 Chipset Display Controller
-	7a37  2K2000/3000 / 3B6000M HDMI Audio Controller
+	7a37  2K2000/3000 / 3B6000M / 7A2000 Chipset HDMI Audio Controller
 	7a39  2K2000 / 7A2000 Chipset PCIe x1 Root Port
 	7a3e  2K2000 RNG Controller
 	7a42  Advanced Peripheral Bus Controller [Chipset / CPU inside]
@@ -191,6 +191,10 @@
 	0202  GP202
 0721  Sapphire, Inc.
 0731  Jingjia Microelectronics Co Ltd
+	0100  JMN100
+		0731 0101  JMN100 16G
+	1050  JM1050
+		0731 1051  JM1050 8G
 	1100  JM1100
 		0731 1101  JM1100-C
 		0731 1102  JM1100-II
@@ -199,6 +203,11 @@
 		0731 1105  JM1100-Y
 		0731 1106  JM1100-EI
 		0731 1107  JM1100-EM
+		0731 1108  JY1008
+		0731 1109  JY1032
+	1102  JM1100-Y
+		0731 1121  JY1032 LE 64G
+		0731 1122  JY1032 LE 32G
 	7200  JM7200 Series GPU
 		0731 7201  JM7201
 		0731 7202  JM7202
@@ -241,6 +250,11 @@
 	f011  JM1100-IV
 	f111  JM1100-MV
 	ff11  JM1100-YV
+		0731 1105  JM11 Series
+		0731 1108  JY1008 vGPU
+		0731 1109  JY1032 vGPU
+		0731 1121  JY1032 LE vGPU
+		0731 1122  JY1032 LE vGPU
 0771  Xi'an Microelectronics Technology Institute
 0777  Ubiquiti Networks, Inc.
 0795  Wired Inc.
@@ -642,6 +656,7 @@
 	0072  SAS2008 PCI-Express Fusion-MPT SAS-2 [Falcon]
 		1000 3020  9211-8i
 		1000 3040  9210-8i
+		1000 3060  9212-4i4e
 		1000 3080  9200-8e [LSI SAS 6Gb/s SAS/SATA PCIe x8 External HBA]
 		1000 30b0  9200-8e [LSI SAS 6Gb/s SAS/SATA PCIe x8 External HBA]
 		1000 30e0  9202-16e
@@ -1302,7 +1317,10 @@
 # Used in the Sony PlayStation 5 Phat
 	13db  Cyan Skillfish [PlayStation 5 APU]
 	13e9  Ariel/Navi10Lite
+	13ea  Cyan Skillfish HDMI/DP Audio Controller
 	13f9  Oberon/Navi12Lite
+# Confirmed on PS5 Phat CFI-1016B; see also 13db
+	13fb  Cyan Skillfish [PlayStation 5 APU]
 	13fe  Cyan Skillfish [BC-250]
 # Used in the Steam Deck OLED
 	1435  Sephiroth [AMD Custom GPU 0405]
@@ -7200,9 +7218,12 @@
 	8241  TUSB73x0 SuperSpeed USB 3.0 xHCI Host Controller
 		1014 04b2  S824 (8286-42A)
 	8400  ACX 100 22Mbps Wireless Interface
+		111a 1021  SpeedStream 1021 (SS1021) Wireless Cardbus PC Card
 		1186 3b00  DWL-650+ PC Card cardbus 22Mbs Wireless Adapter [AirPlus]
 		1186 3b01  DWL-520+ 22Mbps PCI Wireless Adapter
 		1395 2201  WL22-PC
+		167d b230  Netopia TER/WPC11N1 Wireless LAN Card
+		16a5 1801  WE302-TF
 		16ab 8501  WL-8305 IEEE802.11b+ Wireless LAN PCI Adapter
 	8401  ACX 100 22Mbps Wireless Interface
 	8888  Multicore DSP+ARM KeyStone II SOC
@@ -7215,12 +7236,15 @@
 # Found in Philips ADSL ANNEX A WLAN Router SNA6500/18 sold by Belgacom
 		104c 9067  TNETW1130GVF
 		104c 9096  Trendnet TEW-412PC Wireless PCI Adapter (Version A)
+		1154 032c  WLI-CB-G54L
 		1186 3b04  DWL-G520+ Wireless PCI Adapter
 		1186 3b05  DWL-G650+ AirPlusG+ CardBus Wireless LAN
 		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.B1)
 		1385 4c00  WG311v2 802.11g Wireless PCI Adapter
 		13d1 aba0  SWLMP-54108 108Mbps Wireless mini PCI card 802.11g+
 		14ea ab07  GW-NS54GM Wireless Cardbus Adapter
+		167d b260  SWL-2600N
+		16ab 9067  A90-200WG-01 802.11g Wireless PC Card
 		16ec 010d  USR5416 802.11g Wireless Turbo PCI Adapter
 		16ec 010e  USR5410 802.11g Wireless Cardbus Adapter
 		1737 0033  WPC54G v2 802.11g Wireless-G Notebook Adapter
@@ -7372,6 +7396,12 @@
 	90dd  Baikal Memory (DDR3/SPM)
 	90de  Baikal USB 3.0 xHCI Host Controller
 	90eb  CXD90062GG
+	90ec  Salina PCIe Controller
+	9104  Salina Ethernet Controller
+	9105  Salina SATA AHCI Controller
+	9106  Salina SATA AHCI Controller (secondary)
+	9107  Salina PCIe Glue and Miscellaneous Devices
+	9108  Salina USB xHCI Host Controller
 	9121  Nextorage NEM-PA NVMe SSD for PlayStation
 104e  Oak Technology, Inc
 	0017  OTI-64017
@@ -13438,7 +13468,7 @@
 	24dd  GA104M [GeForce RTX 3070 Mobile / Max-Q]
 	24df  GA104M
 	24e0  GA104M [Geforce RTX 3070 Ti Laptop GPU]
-	24fa  GA104 [RTX A4500 Embedded GPU ]
+	24fa  GA104 [RTX A4500 Embedded GPU]
 	2501  GA106 [GeForce RTX 3060]
 	2503  GA106 [GeForce RTX 3060]
 	2504  GA106 [GeForce RTX 3060 Lite Hash Rate]
@@ -13488,7 +13518,7 @@
 	25e5  GA107BM [GeForce RTX 3050 Mobile]
 	25ec  GA107BM / GN20-P0-R-K2 [GeForce RTX 3050 6GB Laptop GPU]
 	25ed  GA107 [GeForce RTX 2050]
-	25f9  GA107 [RTX A1000 Embedded GPU ]
+	25f9  GA107 [RTX A1000 Embedded GPU]
 	25fa  GA107 [RTX A2000 Embedded GPU]
 	25fb  GA107 [RTX A500 Embedded GPU]
 	2681  AD102 [RTX TITAN Ada]
@@ -13611,6 +13641,7 @@
 	2db9  GB207GLM [RTX PRO 500 Blackwell Generation Laptop GPU]
 	2dd8  GB207M [GeForce RTX 5050 Max-Q / Mobile]
 	2df9  GB207GLM [RTX PRO 500 Blackwell Embedded GPU]
+	2e03  GB20B [JMJWOA-Generic-GPU]
 	2e12  GB20B [GB10]
 # N1X
 	2e2a  GB20B [JMJWOA-Generic-GPU]
@@ -14320,7 +14351,8 @@
 	000b  EMU20k2 [Sound Blaster X-Fi Titanium Series]
 		1102 0041  SB0880 [SoundBlaster X-Fi Titanium PCI-e]
 		1102 0062  SB1270 [SoundBlaster X-Fi Titanium HD]
-	0010  CA0132 Sound Core3D [Sound Blaster AE-7]
+	0010  CA0132 Sound Core3D [Sound Blaster AE-7/AE-9]
+		1102 0071  Sound Blaster AE-9
 		1102 0081  Sound Blaster AE-7
 	0012  CA0132 Sound Core3D [Sound Blaster Recon3D / Z-Series / Sound BlasterX AE-5 Plus]
 		1102 0010  SB1570 SB Audigy Fx
@@ -16590,11 +16622,15 @@
 	138f  W8300 802.11 Adapter (rev 07)
 	1fa6  Marvell W8300 802.11 Adapter
 		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.A1)
+		1186 3b09  AirPlus G DWL-G510 Wireless G PCI Card
 	1fa7  88W8310 and 88W8000G [Libertas] 802.11g client chipset
 	1faa  88w8335 [Libertas] 802.11b/g Wireless
+		1186 3b21  EH101 Wireless G Notebook Adapter
+		1186 3b22  EH102 Wireless G Desktop Adapter
 		1385 4e00  WG511v2 54 Mbps Wireless PC Card
 		1385 6b00  WG311v3 802.11g Wireless PCI Adapter
 		1737 0040  WPC54G v5 802.11g Wireless-G Notebook Adapter
+		a727 6802  3CRGPC10075 OfficeConnect Wireless 54Mbps 11g PC Card
 	2211  88SB2211 PCI Express to PCI Bridge
 	2a01  88W8335 [Libertas] 802.11b/g Wireless
 	2a02  88W8361 [TopDog] 802.11n Wireless
@@ -16602,9 +16638,14 @@
 		1385 7c00  WN511T RangeMax Next 300 Mbps Wireless PC Card
 		1385 7c01  WN511T RangeMax Next 300 Mbps Wireless Notebook Adapter
 		1385 7e00  WN311T RangeMax Next 300 Mbps Wireless PCI Adapter
+		1737 0065  WPC4400N Wireless-N Business Notebook Adapter
 		1799 801b  F5D8011 v2 802.11n N1 Wireless Notebook Card
 	2a08  88W8362e [TopDog] 802.11a/b/g/n Wireless
 	2a0a  88W8363 [TopDog] 802.11n Wireless
+	2a0b  88W8363 [TopDog] 802.11n Wireless
+		1154 0356  WLI-CB-AMG144N
+		1154 0357  WLI-CB-AG300N Nfiniti 802.11a/g/b + Draft 802.11n CardBus Card
+		1154 035c  WLI-CB-AMG300N
 	2a0c  88W8363 [TopDog] 802.11n Wireless
 	2a24  88W8363 [TopDog] 802.11n Wireless
 	2a2b  88W8687 [TopDog] 802.11b/g Wireless
@@ -17775,12 +17816,16 @@
 	3872  ISL3872 [Prism 3]
 		1468 0202  LAN-Express IEEE 802.11b Wireless LAN
 	3873  ISL3874 [Prism 2.5]/ISL3872 [Prism 3]
+		10b7 0001  3CRDW696 rev A Wireless LAN PCI Adapter [ISL3874]
 		10cf 1169  MBH7WM01-8734 802.11b Wireless Mini PCI Card [ISL3874]
+		10fc d009  WN-B11/PCIH
 		1186 3501  DWL-520 Wireless PCI Adapter (rev A or B) [ISL3874]
 		1186 3700  DWL-520 Wireless PCI Adapter (rev E1) [ISL3872]
 		1385 4105  MA311 802.11b wireless adapter [ISL3874]
 		1668 0414  HWP01170-01 802.11b PCI Wireless Adapter
+		1668 1406  802MIP 802.11b Mini PCI Adapter [ISL3874]
 		16a5 1601  AIR.mate PC-400 PCI Wireless LAN Adapter
+		16be 2001  CTX712
 		1737 3874  WMP11 v1 802.11b Wireless-B PCI Adapter [ISL3874]
 		4033 7033  PCW200 802.11b Wireless PCI Adapter [ISL3874]
 		8086 2510  M3AWEB Wireless 802.11b MiniPCI Adapter
@@ -19376,6 +19421,8 @@
 13b3  Lanart Corporation
 13b4  Wellbean Co Inc
 13b5  ARM
+	0300  Integrated [AGI CPU] PCIe/CXL Root Port
+	0301  Integrated [AGI CPU] Platform PCIe Root Port
 13b6  Dlog GmbH
 13b7  Logic Devices Inc
 13b8  Nokia Telecommunications oy
@@ -19769,6 +19816,10 @@
 	5821  Xenos GPU (Zephyr/Falcon)
 	5831  Xenos GPU (Jasper)
 	5841  Xenos GPU (Slim)
+	c030  OpenVMM PCIe Root Port
+	c031  OpenVMM PCIe Switch Upstream Port
+	c032  OpenVMM PCIe Switch Downstream Port
+	c03e  OpenVMM NVMe Controller
 1415  Oxford Semiconductor Ltd
 	8401  OX9162 Mode 1 (8-bit bus)
 	8403  OX9162 Mode 0 (parallel port)
@@ -21944,6 +21995,7 @@
 		1154 0330  Buffalo WLI2-PCI-G54S High Speed Mode Wireless Desktop Adapter
 		144f 7050  eMachines M6805 802.11g Built-in Wireless
 		144f 7051  Sonnet Aria Extreme PCI
+		16a5 1604  WE602-B
 		1737 0013  WMP54G v1 802.11g PCI Adapter
 		1737 0014  WMP54G v2 802.11g PCI Adapter
 		1737 0015  WMP54GS v1.0 802.11g Wireless-G PCI Adapter with SpeedBooster
@@ -23091,6 +23143,8 @@
 	2100  CX8 Family [CX8 Data Direct Interface]
 # NVLink Chip to Chip Link
 	2101  CX10 Family [ConnectX-10 NVLink-C2C]
+# Starting with CX10 generation
+	2300  ConnectX/BlueField Family Hardware Performance Monitors [HWPM]
 	4117  MT27712A0-FDCF-AE
 		1bd4 0039  SN10XMP2P25
 		1bd4 003a  25G SFP28 SP EO251FM9 Adapter
@@ -23724,6 +23778,7 @@
 		1186 3a67  DWL-G650M Super G MIMO Wireless Notebook Adapter
 		1186 3a68  DWL-G520M Wireless 108G MIMO Desktop Adapter
 		187e 340e  M-302 802.11g Wireless PCI Adapter
+		1976 1600  TEW-603PI 108Mbps 802.11g Wireless PCI Adapter
 		1976 2003  TEW-601PC 802.11g Wireless CardBus Adapter
 	0023  AR5416 Wireless Network Adapter [AR5008 802.11(a)bgn]
 		0308 340b  NWD-170N 802.11bgn Wireless CardBus Adapter
@@ -24297,6 +24352,8 @@
 	a300  OCTEON TX CN83XX
 	af00  CN99xx [ThunderX2] Integrated PCI Host bridge
 	af84  CN99xx [ThunderX2] Integrated PCI Express RP Bridge
+# Name inferred from https://www.prnewswire.com/news-releases/cavium-and-xpliant-introduce-a-fully-programmable-switch-silicon-family-scaling-to-32-terabits-per-second-275262511.html
+	f010  XPliant CNX880xx Network Processor
 1787  Hightech Information System Ltd.
 1789  Ennyah Technologies Corp.
 # also used by Struck Innovative Systeme for joint developments
@@ -24398,11 +24455,16 @@
 # nee Airgo Networks, Inc.
 17cb  Qualcomm Technologies, Inc
 	0001  AGN100 802.11 a/b/g True MIMO Wireless Card
+		1154 0337  WLI-CB-G108
 		1385 5c00  WGM511 Pre-N 802.11g Wireless CardBus Adapter
+		14ea 6101  CQW-NS108G
+		1737 0037  WPC54GX Wireless-G Notebook Adapter with SRX
 		1737 0045  WMP54GX v1 802.11g Wireless-G PCI Adapter with SRX
 	0002  AGN300 802.11 a/b/g True MIMO Wireless Card
+		1043 106f  WL-106gM 240 MIMO Wireless CardBus Adapter
 		1385 6d00  WPNT511 RangeMax 240 Mbps Wireless CardBus Adapter
 		1737 0054  WPC54GX4 v1 802.11g Wireless-G Notebook Adapter with SRX400
+		1737 0056  WMP54GX4 Wireless-G PCI Adapter with SRX400
 	0104  APQ8096 PCIe Root Complex [Snapdragon 820]
 	0105  MSM8998 PCIe Root Complex
 	0106  SDM850 PCIe Root Complex [Snapdragon 850]
@@ -24653,6 +24715,7 @@
 	2120  IPN 2120 802.11b
 		1737 0020  WMP11 v4 802.11b Wireless-B PCI Adapter
 	2220  IPN 2220 802.11g
+		1154 0334  WLI2-CB-G54L
 		1468 0305  T60N871 802.11g Mini PCI Wireless Adapter
 		1737 0029  WPC54G v4 802.11g Wireless-G Notebook Adapter
 17ff  Benq Corporation
@@ -24728,15 +24791,18 @@
 	0301  RT2561/RT61 802.11g PCI
 		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E1)
 		1186 3c09  DWL-G510 Rev C
+		1259 c123  CG-WLCB54GPX
 		13d1 abe3  miniPCI Pluscom 802.11 a/b/g
 		1458 e933  GN-WI01GS
 		1458 e934  GN-WP01GS
 		1462 b833  MP54G5 (MS-6833B)
+		1462 b834  PC60G (MS-6834B) Wireless 11g Turbo G PCI Card
 		1737 0055  WMP54G v4.1
 		1799 700e  F5D7000 v6000 Wireless G Desktop Card
 		1799 701e  F5D7010 v6000 Wireless G Notebook Card
 		17f9 0012  AWLC3026T 802.11g Wireless CardBus Adapter
 		1814 2561  EW-7108PCg/EW-7128g
+		182d 90aa  WL-170 Wireless Network Cardbus Card
 	0302  RT2561/RT61 rev B 802.11g
 		1186 3a71  DWA-510 Wireless G Desktop Adapter
 		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E2)
@@ -25472,6 +25538,7 @@
 	5028  PS5028-E28 PCIe5 NVMe Controller
 	5029  PS5029-E29T PCIe4 NVMe Controller (DRAM-less)
 	5031  PS5031-E31T PCIe5 NVMe Controller
+	5037  PS5037-E37T PCIe5 NVMe Controller (DRAM-less)
 	5302  PS5302-X2 PCIe5 NVMe Controller
 1989  Montilio Inc.
 	0001  RapidFile Bridge
@@ -25597,8 +25664,12 @@
 		19e5 0051  Hi1822 SP681 (2*25/10GE)
 		19e5 0052  Hi1822 SP680 (4*25/10GE)
 		19e5 00a1  Hi1822 SP670 (2*100GE)
+		19e5 0152  Hi1822 SP623Q (4*25/10GE)
+		19e5 01a1  Hi1822 SP625D (2*100GE)
 	0229  Hi1872 Family
 	022a  Hi1872 Family Virtual Function
+	0230  Hi1825 Family
+	0231  Hi1825 Family Virtual Function
 	1710  iBMA Virtual Network Adapter
 	1711  Hi171x Series [iBMC Intelligent Management system chip w/VGA support]
 	1712  Intelligent Management system chip Virtual Network Adapter
@@ -26235,6 +26306,7 @@
 	2b43  NXP 88W9098 Wi-Fi 6 (ax) MAC #1
 	2b44  NXP 88W9098 Wi-Fi 6 (ax) MAC #2
 	2b45  NXP 88W9098 Bluetooth 5.3
+	2b56  NXP IW620 Wi-Fi 6 (ax) + Bluetooth 5.3 Combo
 # some cards use this device ID instead of 9230
 	624e  DAWICONTROL DC-624e RAID
 		dc93 624e  DC-624e RAID
@@ -26368,6 +26440,7 @@
 	2720  Ultrastar DC SN650 NVMe SSD
 	2721  Ultrastar DC SN650 NVMe SSD
 	2722  Ultrastar DC SN655 NVMe SSD
+	2750  Ultrastar DC SN861 NVMe SSD
 	2751  Ultrastar DC SN861 NVMe SSD
 	3001  RapidFlex C2000 NVMe Initiator
 	3714  PC SN730 NVMe SSD
@@ -26519,6 +26592,9 @@
 	1001  PCIe 3TG6-P Controller
 	1002  PCIe 3TE6 Controller (DRAM-less)
 	1160  PCIe 3TE2 Controller
+	1202  PCIe 3TE8 Controller
+	120a  PCIe 3IE8 Controller
+	120b  PCIe 3TO8 Controller
 	1321  PCIe 4TG-P Controller
 	1322  PCIe 4TE Controller
 	1602  PCIe 4TE3 Controller
@@ -26526,9 +26602,13 @@
 	2262  PCIe 3TG3-P Controller
 	5208  PCIe 3TE7 Controller
 	5216  PCIe 3TE9 controller
+	521a  PCIe 3IE9 Controller
+	5220  PCIe 4TE2 Controller
+	522a  PCIe 4IE2 Controller
 	5236  PCIe 4TG2-P Controller
 # based on PCIe 4TG2-P Controller, for 4TS2-P series
 	523a  PCIe 4TS2-P Controller
+	523b  PCIe 4IG2-P Controller
 # based on SM8366 Controller
 	8366  PCIe 5TS-P Controller
 1bcd  Apacer Technology
@@ -26686,6 +26766,7 @@
 	a015  FB2CGHH Capture 2x100Gb [Tivoli]
 	a016  FB2CG Capture 8x25Gb [Savona]
 	a017  FB2CGHH Capture 8x25Gb [Tivoli] a017
+	a01b  FB2CDG1 Capture 2x100Gb [Thunderfjord]
 # Used on V120 VME Crate Controller
 1c32  Highland Technology, Inc.
 1c33  Daktronics, Inc
@@ -26989,6 +27070,7 @@
 	33f4  IM2P33F4 NVMe SSD (DRAM-less)
 	33f8  IM2P33F8 series NVMe SSD (DRAM-less)
 	413d  SM2P41D3Q NVMe SSD (DRAM-less)
+	41b8  IM2P41B8P NVMe SSD
 	41c3  SM2P41C3 NVMe SSD (DRAM-less)
 	41c8  SM2P41C8 NVMe SSD (DRAM-less)
 	41d3  SM2P41D3 NVMe SSD (DRAM-less)
@@ -27016,6 +27098,7 @@
 	634c  LEGEND 820 NVMe SSD (DRAM-less)
 	635a  XPG GAMMIX S60 NVMe SSD (DRAM-less)
 	636a  XPG GAMMIX S55 NVMe SSD (DRAM-less)
+	641a  LEGEND 970 PRO NVMe SSD
 	642a  XPG GAMMIX S50 CORE NVMe SSD (DRAM-less)
 	646a  XPG MARS 980 BLADE NVMe SSD
 	648a  LEGEND 860 NVMe SSD (DRAM-less)
@@ -27267,14 +27350,14 @@
 	0714  ZX-100/ZX-200 PCI Express Root Port
 	0715  ZX-100/ZX-200 PCI Express Root Port
 	0716  ZX-D PCI Express Root Port
-	0717  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	0718  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	0719  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
+	0717  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	0718  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	0719  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
 	071a  KX-5000/KX-6000/KX-6000G/KH-40000 PCI Express Root Port
-	071b  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071c  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071d  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
-	071e  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Express Root Port
+	071b  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071c  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071d  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
+	071e  KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Express Root Port
 	071f  ZX-200 Upstream Port of PCI Express Switch
 	0720  ZX-200 PCIE RC6 controller
 	0721  ZX-200 Downstream Port of PCI Express Switch
@@ -27290,26 +27373,58 @@
 	0739  KX-7000 PCIE Express Root Port
 	073a  KX-7000 PCIE Express Root Port
 	073b  KX-7000 PCIE Express Root Port
+	073c  KH-50000 PCI Express Root Port
+	073d  KH-50000 PCI Express Root Port
+	073e  KH-50000 PCI Express Root Port
+	073f  KH-50000 PCI Express Root Port
+	0740  KH-50000 PCI Express Root Port
+	0741  KH-50000 PCI Express Root Port
+	0742  KH-50000 PCI Express Root Port
+	0743  KH-50000 PCI Express Root Port
+	0744  KH-50000 PCI Express Root Port
+	0745  KH-50000 PCI Express Root Port
+	0746  KH-50000 PCI Express Root Port
+	0747  KH-50000 PCI Express Root Port
+	0748  KH-50000 PCI Express Root Port
+	0749  KH-50000 PCI Express Root Port
+	074a  KH-50000 PCI Express Root Port
+	074b  KH-50000 PCI Express Root Port
+	074c  KH-50000 PCI Express Root Port
+	074d  KH-50000 PCI Express Root Port
+	074e  KH-50000 PCI Express Root Port
+	074f  KH-50000 PCI Express Root Port
+	0750  KH-50000 PCI Express Root Port
+	0751  KH-50000 PCI Express Root Port
+	0752  KH-50000 PCI Express Root Port
+	0757  KH-50000 PCI Express Root Port
+	0758  KH-50000 PCI Express Root Port
+	0759  KH-50000 PCI Express Root Port
+	075a  KH-50000 PCI Express Root Port
+	075b  KH-50000 PCI Express Root Port
+	075c  KH-50000 PCI Express Root Port
+	075d  KH-50000 PCI Express Root Port
+	075e  KH-50000 PCI Express Root Port
 	1000  ZX-D Standard Host Bridge
-	1001  ZX-D/ZX-E/KH-40000/KX-7000 Miscellaneous Bus
+	1001  ZX-D/ZX-E/KH-40000/KX-7000/KH-50000 Miscellaneous Bus
 	1003  ZX-E Standard Host Bridge
 	1005  KH-40000 Standard Host Bridge
 	1006  KX-6000G Standard Host Bridge
 	1007  KX-7000 Standard Host Bridge
+	1008  KH-50000 Standard Host Bridge
 	3001  ZX-100 Standard Host Bridge
 	300a  ZX-100 Miscellaneous Bus
-	3038  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Universal PCI to USB Host Controller
-	3104  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Enhanced PCI to USB Host Controller
-	31b0  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
-	31b1  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
+	3038  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Universal PCI to USB Host Controller
+	3104  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Enhanced PCI to USB Host Controller
+	31b0  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
+	31b1  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
 	31b2  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 DRAM Controller
-	31b3  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Power Management Controller
-	31b4  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 I/O APIC
-	31b5  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Scratch Device
-	31b7  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 Standard Host Bridge
+	31b3  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Power Management Controller
+	31b4  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 I/O APIC
+	31b5  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Scratch Device
+	31b7  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 Standard Host Bridge
 	31b8  ZX-100/ZX-D PCI to PCI Bridge
 	3200  KX-7000 Host Bridge
-	3288  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 High Definition Audio Controller
+	3288  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 High Definition Audio Controller
 	345b  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000 Miscellaneous Bus
 	3a02  ZX-100 C-320 GPU
 	3a03  ZX-D C-860 GPU
@@ -27322,12 +27437,12 @@
 	3c00  KH-40000/KX-7000 DRAM Controller
 	3c02  KX-6000G DRAM Controller
 	3d01  KX-6000G C-1080 GPU
-	9002  ZX-100/ZX-200/KH-40000/KX-7000 EIDE Controller
+	9002  ZX-100/ZX-200/KH-40000/KX-7000/KH-50000 EIDE Controller
 	9003  ZX-100/KX-6000/KX-6000G EIDE Controller
-	9043  KX-6000G/KH-40000/KX-7000 RAID Controller
+	9043  KX-6000G/KH-40000/KX-7000/KH-50000 RAID Controller
 	9045  ZX-100/ZX-D/ZX-E RAID Accelerator 0
 	9046  ZX-D/ZX-E RAID Accelerator 1
-	9083  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000 StorX AHCI Controller
+	9083  ZX-100/ZX-200/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 StorX AHCI Controller
 	9084  ZX-100 StorX AHCI Controller
 	9100  ZX-200 Cross bus
 	9101  ZX-200 Traffic Controller
@@ -27344,12 +27459,13 @@
 	9204  KX-6000/KX-6000G/KX-7000 USB3 xHCI Host Controller
 	9205  KH-40000 USB eXtensible Host Controller
 	9206  KX-7000 USB4 Contoller
+	9207  KH-50000 USB eXtensible Host Controller
 	9286  ZX-D eMMC Host Controller
-	9300  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 eSPI Host Controller
+	9300  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 eSPI Host Controller
 	9500  KX-7000 I2S Controller
 	9501  KX-7000 I2S Controller
 	95d0  ZX-100 Universal SD Host Controller
-	f410  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000 PCI Com Port
+	f410  ZX-100/KX-5000/KX-6000/KX-6000G/KH-40000/KX-7000/KH-50000 PCI Com Port
 1d18  RME
 	0001  Fireface UFX+
 # acquired by Intel
@@ -28259,6 +28375,7 @@
 	0018  Exceria Pro NVMe SSD
 	001a  NVMe SSD Controller BG6 (DRAM-less)
 	001b  NVMe SSD Controller EG6 (DRAM-less)
+	001e  NVMe SSD Controller LD2-L
 	001f  NVMe SSD Controller CD8
 		1028 2223  DC NVMe CD8 U.2 SED 15.36TB
 		1028 2224  DC NVMe CD8 U.2 SED 7.68TB
@@ -28386,12 +28503,14 @@
 		1028 23f8  KCD9XPJE3T20
 		1028 23f9  KCD9XPJE6T40
 		1028 23fa  KCD9XPJE12T8
+	003a  NVMe SSD Controller BG8 (DRAM-less)
 	003b  Exceria Basic NVMe SSD (DRAM-less)
 	003d  LC9 E3.L NVMe SSD
 		1028 244f  RLC9GZV245T
 		1028 2450  RLC9CZV245T
 	003e  LC9 E3.S NVMe SSD
 	003f  LC9 U.2 NVMe SSD
+	0042  NVMe SSD Controller LD4
 1e17  Arnold & Richter Cine Technik GmbH & Co. Betriebs KG
 1e18  Beijing GuangRunTong Technology Development Co.,Ltd
 1e24  Squirrels Research Labs
@@ -28410,6 +28529,8 @@
 1e30  Sophgo
 	1684  BM1684 [Sophon Series Deep Learning Accelerator]
 	2042  SG2042 Root Complex
+# https://www.sord.co.jp/
+1e31  SORD CORPORATION
 1e36  Shanghai Enflame Technology Co. Ltd
 	0001  T10 [CloudBlazer]
 	0002  T11 [CloudBlazer]
@@ -28929,6 +29050,9 @@
 		1ec8 12a2  Fantasy I Device
 	8810  Fantasy I
 		1ec8 12a2  Fantasy I Device
+# Also in the Windows driver INF installation file.
+	8811  Fantasy I-V
+	8820  Fantasy III
 	8900  GR308
 	8902  GR3 Audio
 	8904  GR308
@@ -29520,7 +29644,8 @@
 	1003  K2-Pro Family [FLEXFLOW-2200T MGMT Function]
 	1004  K2-Pro Family [FLEXFLOW-2200T DATA Offload Engine]
 	1005  CONFLUX-2200P NVMe Controller
-	1011  K3 Family [FLEXFLOW-3100T]
+	1011  K3-T Family
+		1dcf 0363  K3_F2_10G_PCIE 2*10GE Ethernet Adapter
 		1f47 0001  FLEXFLOW-3100T 2*10GE Ethernet Adapter
 		1f47 0002  FLEXFLOW-3100T 4*10GE Ethernet Adapter
 		1f47 0003  FLEXFLOW-3100T 2*25GE Ethernet Adapter
@@ -29531,10 +29656,9 @@
 		1f47 0008  FLEXFLOW-3100T 4*10GE Ethernet Adapter
 		1f47 0009  FLEXFLOW-3100T 2*25GE Ethernet Adapter
 		1f47 000a  FLEXFLOW-3100T 4*25GE Ethernet Adapter
-	1012  K3 Family [FLEXFLOW-3100T Virtual Function]
-	1013  K3 Family [FLEXFLOW-3100T MGMT Function]
+	1012  K3-T Family [Virtual Function]
+	1013  K3-T Family [MGMT Function]
 	1105  CONFLUX-2200P NVMe Controller [Virtual Function]
-	1203  K2-Pro Family [FLEXFLOW-2200T RoCEv2 Network Controller]
 # Network Accelerating Card
 	2018  DPU Card
 # Network Accelerating Card
@@ -29568,7 +29692,6 @@
 		1f47 0006  Ethernet 25G 2P FLEXFLOW-2200R
 		1f47 0007  Ethernet 50G 2P FLEXFLOW-2200R
 		1f47 0008  Ethernet 100G 2P FLEXFLOW-2200R
-	3303  K3 Family [CONFLUX-3100R MGMT Function]
 	4001  K2-Pro Family [CONFLUX-2200E]
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200E
 		1f47 0002  Ethernet 40G 2P CONFLUX-2200E
@@ -29581,7 +29704,13 @@
 	4002  K2-Pro Family [CONFLUX-2200E Virtual Function]
 	4003  K2-Pro Family [CONFLUX-2200E MGMT Function]
 	4004  K2-Pro Family [CONFLUX-2200E DATA Offload Engine]
-	4203  K2-Pro Family [CONFLUX-2200E RoCEv2 Network Controller]
+	4011  K3 Family [CONFLUX-3100E]
+		1f47 0001  CONFLUX-3100E 2*10GE Ethernet Adapter
+		1f47 0002  CONFLUX-3100E 4*10GE Ethernet Adapter
+		1f47 0003  CONFLUX-3100E 2*25GE Ethernet Adapter
+		1f47 0004  CONFLUX-3100E 4*25GE Ethernet Adapter
+	4012  K3 Family [CONFLUX-3100E Virtual Function]
+	4013  K3 Family [CONFLUX-3100E MGMT Function]
 	5001  CONFLUX-2200P Ethernet Controller
 		1f47 0001  Ethernet 25G 2P CONFLUX-2200P
 		1f47 0003  Ethernet 100G 2P CONFLUX-2200P
@@ -29664,7 +29793,11 @@
 	00f1  JetStream [DMX F1 Transparent NIC]
 1f8c  Exascend,INC.
 	8008  SM8008 NVMe SSD [Px5 Series SSD]
-	8366  SM8366 NVMe SSD
+		1f8c 0001  PD5 Series General
+		1f8c 0002  Px5 Series General
+	8366  SM8366 NVMe SSD [PD5 Series SSD]
+		1f8c 0001  PD5 Series General
+		1f8c 0002  Px5 Series General
 1f90  Quside Technologies
 	7024  QRNG PCIe Device
 	7025  QRNG PCIe Device
@@ -29747,7 +29880,7 @@
 	0004  D20 Pro
 	0005  D20 Plus N
 	0006  D20 Pro N
-	0101  D2
+	0101  T1
 # nee Tumsan Oy
 1fc0  Ascom (Finland) Oy
 	0300  E2200 Dual E1/Rawpipe Card
@@ -29916,11 +30049,20 @@
 		1ff2 0b23  3260-16i Tri-mode RAID Adapter
 		1ff2 0b24  3260-8i Tri-mode RAID Adapter
 1ff4  DEEPX Co., Ltd.
-	0000  DX_M1
-	0001  DX_M1A
-	1000  DX_H1
-	2000  DX_VNPU_M1
-	2001  DX_VNPU
+# DX-M1, DX-M1 M.2 Module
+	0100  M1 [Series]
+# DX-H1 Card with M1
+	0101  M1 [H1]
+# DX-H1 V-NPU Card with M1
+	0102  M1 [H1 V-NPU]
+# DX-M1M, DX-M1M M.2 Module
+	0110  M1M [Series]
+# DX-H1M Card with M1M
+	0111  M1M [H1M]
+# DX-H1M V-NPU Card with M1M
+	0112  M1M [H1M V-NPU]
+# DX-H1/H1M V-NPU Card Video Processing Unit
+	2001  VPU [H1/H1M V-NPU]
 1ff8  Beijing Gengtu Technology Co.Ltd
 	2000  GT6910
 	2010  GT6908
@@ -30147,8 +30289,9 @@
 209b  BitIntelligence Technology
 	1000  TCU Family - TCU-1
 	1001  TCU Family - TCU-1 Virtual Function
+	1002  TCU Family - TCU-1 PCIe Switch
 209f  Mobilint, Inc.
-20a1  Etched AI, Inc.
+20a1  Etched, Inc.
 	0001  Sohu
 20a6  XCENA, Inc.
 20a7  EEVengers Inc.
@@ -30158,6 +30301,7 @@
 	1008  NEOTAPX FPGA Accelerator Card
 	1104  NEOTAPX FPGA Timing Synchronization Card
 	1200  MUX Ultimate FPGA Accelerator Card
+	1201  MUX Ultimate FPGA Accelerator Card
 20b5  Shanghai StarFive Technology Co., Ltd.
 20ba  Hangzhou Hikstorage Technology Co., Ltd.
 	1202  NAND memory controller
@@ -31395,7 +31539,7 @@
 	0697  W480 Chipset LPC/eSPI Controller
 	06a0  400 Series Chipset Family P2SB
 	06a1  400 Series Chipset Family PMC
-	06a3  400 Series Chipset Platform SMBus
+	06a3  400 Series Chipset Family SMBus
 	06a4  400 Series Chipset Family SPI (flash) Controller
 	06a6  400 Series Chipset Family Trace Hub
 	06a8  400 Series Chipset Family UART #0
@@ -36400,7 +36544,8 @@
 		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 		e4bf cc47  CCG-RUMBA
 	2880  Ice Lake DDRIO Registers
-	28c0  Volume Management Device NVMe RAID Controller
+# also seen in Xeon 6900 6700 6500 Series with P-Cores Processors
+	28c0  Volume Management Device (VMD)
 		1d49 011a  Intel VROC (VMD NVMe RAID) for ThinkSystem V4 PL
 	2912  82801IH (ICH9DH) LPC Interface Controller
 	2914  82801IO (ICH9DO) LPC Interface Controller
@@ -38874,11 +39019,11 @@
 	5aee  Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #4
 	5af0  Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge
 	6400  Core Ultra 200V Series Processors with 4 P-Cores 4 E-Cores Host Bridge
-	641d  Lunar Lake-M Dynamic Tuning Technology
+	641d  Core Ultra 200V Series Processors Dynamic Tuning Technology (DTT)
 	6420  Lunar Lake [Intel Graphics]
-	643e  Lunar Lake NPU
-	645d  Lunar Lake IPU
-	647d  Lunar Lake-M Crashlog and Telemetry
+	643e  Core Ultra 200V Series Processors NPU
+	645d  Core Ultra 200V Series Processors IPU
+	647d  Core Ultra 200V Series Processors Crash Log and Telemetry
 	64a0  Core Ultra 200V Series Processors Arc Graphics 130V/140V GPU
 	64b0  Lunar Lake [Intel Graphics]
 	65c0  5100 Chipset Memory Controller Hub
@@ -39229,7 +39374,7 @@
 	777a  Core Ultra 200H/200V Series Processors I2C #2
 	777b  Core Ultra 200H/200V Series Processors I2C #3
 	777c  Core Ultra 200H/200V Series Processors I3C
-	777d  Arrow Lake USB 3.2 xHCI Controller
+	777d  Core Ultra 200H/200V Series Processors Standalone xHCI Controller
 	777e  Core Ultra 200H/200V Series Processors Standalone USB Device Controller
 	777f  Core Ultra 200H/200V Series Processors Shared SRAM
 	7800  82740 (i740) AGP Graphics Accelerator
@@ -39402,15 +39547,15 @@
 	7afd  600 Series Chipset Family I2C Controller #5
 	7afe  600 Series Chipset Family UART #2
 	7d01  Meteor Lake-H 6p+8e cores Host Bridge/DRAM Controller
-	7d03  Meteor Lake-P Dynamic Tuning Technology
-	7d06  Arrow Lake-H 6p+8e cores Host Bridge/DRAM Controller
-	7d0b  Volume Management Device NVMe RAID Controller Intel Corporation
-	7d0d  Meteor Lake-P Platform Monitoring Technology
-	7d19  Meteor Lake IPU
+	7d03  Core Ultra 200H/200V Series Processors Dynamic Tuning Technology (DTT)
+	7d06  Core Ultra 200H Series Processors with 6 P-Cores 8 E-Cores Host Bridge
+	7d0b  Core Ultra 200H/200V Series Processors VMD
+	7d0d  Core Ultra 200H/200V Series Processors Platform Monitoring Technology (PMT)
+	7d19  Core Ultra 200H/200V Series Processors IPU
 	7d1a  Core Ultra 200S/200S-Plus Series Processors with 8 P-Cores 16 E-Cores Host Bridge
 	7d1b  Core Ultra 200S Series Processors with 8 P-Cores 12 E-Cores Host Bridge
-	7d1c  Arrow Lake-HX 8p+16e cores Host Bridge
-	7d1d  Meteor Lake NPU
+	7d1c  Core Ultra 200HX/HX-Plus Series Processors with 8 P-Cores 16 E-Cores Host Bridge
+	7d1d  Core Ultra 200H/200V Series Processors NPU
 	7d29  Core Ultra 200S-Plus Series Processors with 6 P-Cores 12 E-Cores Host Bridge
 	7d2a  Core Ultra 200S Series Processors with 6 P-Cores 8 E-Cores Host Bridge
 	7d2d  Core Ultra 200HX/HX-Plus Series Processors with 8 P-Cores 12 E-Cores Host Bridge
@@ -39456,14 +39601,14 @@
 	7e7d  Meteor Lake-P USB 3.2 Gen 2x1 xHCI Host Controller
 	7e7e  Meteor Lake-P USB Device Controller
 	7e7f  Meteor Lake-H/U Shared SRAM
-	7ec0  Meteor Lake-P Thunderbolt 4 USB Controller
+	7ec0  Core Ultra 200 Series Processors USB xHCI
 	7ec1  Core Ultra 200 Series Processors USB xDCI
-	7ec2  Meteor Lake-P Thunderbolt 4 NHI #0
-	7ec3  Meteor Lake-P Thunderbolt 4 NHI #1
-	7ec4  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #0
-	7ec5  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1
-	7ec6  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #2
-	7ec7  Meteor Lake-P Thunderbolt 4 PCI Express Root Port #3
+	7ec2  Core Ultra 200 Series Processors Thunderbolt DMA0
+	7ec3  Core Ultra 200 Series Processors Thunderbolt DMA1
+	7ec4  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #16
+	7ec5  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #17
+	7ec6  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #18
+	7ec7  Core Ultra 200 Series Processors USB Type-C Subsystem PCIe Root Port #19
 	7ec8  Core Ultra 200 Series Processors P2SB (IOE)
 	7ec9  Core Ultra 200H/200V Series Processors IEH (IOE)
 	7eca  Core Ultra 200 Series Processors PCIe Root Port #10
@@ -40719,20 +40864,67 @@
 		1028 0869  Vostro 3470
 	a37b  300/C240 Series Chipset Family SPI #2
 	a37c  300/C240 Series Chipset Family Integrated Sensor Hub
-	a382  400 Series Chipset Family SATA AHCI Controller
-	a394  Comet Lake PCI Express Root Port #05
-	a397  Comet Lake PCI Express Root Port #08
-	a398  Comet Lake PCI Express Root Port 9
-	a39a  Comet Lake PCI Express Root Port 11
-	a3a1  Cannon Lake PCH Power Management Controller
-	a3a3  Comet Lake PCH-V SMBus Host Controller
-	a3af  Comet Lake PCH-V USB Controller
-	a3b1  Comet Lake PCH-V Thermal Subsystem
-	a3ba  Comet Lake PCH-V HECI Controller
+	a382  B460/H410 Chipset SATA Controller (AHCI)
+	a384  B460/H410 Chipset SATA Controller (RAID 0/1/5/10) Not Premium
+	a386  B460/H410 Chipset SATA Controller (RAID 0/1/5/10) Premium
+	a38e  B460/H410 Chipset SATA Controller (RST Optane)
+	a390  B460/H410 Chipset PCIe Root Port #1
+	a391  B460/H410 Chipset PCIe Root Port #2
+	a392  B460/H410 Chipset PCIe Root Port #3
+	a393  B460/H410 Chipset PCIe Root Port #4
+	a394  B460/H410 Chipset PCIe Root Port #5
+	a395  B460/H410 Chipset PCIe Root Port #6
+	a396  B460/H410 Chipset PCIe Root Port #7
+	a397  B460/H410 Chipset PCIe Root Port #8
+	a398  B460/H410 Chipset PCIe Root Port #9
+	a399  B460/H410 Chipset PCIe Root Port #10
+	a39a  B460/H410 Chipset PCIe Root Port #11
+	a39b  B460/H410 Chipset PCIe Root Port #12
+	a39c  B460/H410 Chipset PCIe Root Port #13
+	a39d  B460/H410 Chipset PCIe Root Port #14
+	a39e  B460/H410 Chipset PCIe Root Port #15
+	a39f  B460/H410 Chipset PCIe Root Port #16
+	a3a0  B460/H410 Chipset P2SB
+	a3a1  B460/H410 Chipset PMC
+	a3a3  B460/H410 Chipset SMBus
+	a3a4  B460/H410 Chipset SPI Controller
+	a3a6  B460/H410 Chipset Trace Hub
+	a3a7  B460/H410 Chipset UART #0
+	a3a8  B460/H410 Chipset UART #1
+	a3a9  B460/H410 Chipset SPI #0
+	a3aa  B460/H410 Chipset SPI #1
+	a3af  B460/H410 Chipset USB 3.2 Gen 1x1 (5 Gbs) xHCI Controller
+	a3b0  B460/H410 Chipset USB Device Controller
+	a3b1  B460/H410 Chipset Thermal Subsystem
+	a3b5  B460/H410 Chipset ISH
+	a3ba  B460/H410 Chipset CSME HECI #1
+	a3bb  B460/H410 Chipset CSME HECI #2
+	a3bc  B460/H410 Chipset CSME IDE Redirection
+	a3bd  B460/H410 Chipset CSME Keyboard and Text (KT) Redirection
+	a3be  B460/H410 Chipset CSME HECI #3
 	a3c8  B460 Chipset LPC/eSPI Controller
 	a3da  H410 Chipset LPC/eSPI Controller
-	a3eb  Comet Lake PCI Express Root Port #21
-	a3f0  Comet Lake PCH-V cAVS
+	a3e0  B460/H410 Chipset I2C #0
+	a3e1  B460/H410 Chipset I2C #1
+	a3e2  B460/H410 Chipset I2C #2
+	a3e3  B460/H410 Chipset I2C #3
+	a3e6  B460/H410 Chipset UART #2
+	a3e7  B460/H410 Chipset PCIe Root Port #17
+	a3e8  B460/H410 Chipset PCIe Root Port #18
+	a3e9  B460/H410 Chipset PCIe Root Port #19
+	a3ea  B460/H410 Chipset PCIe Root Port #20
+	a3eb  B460/H410 Chipset PCIe Root Port #21
+	a3ec  B460/H410 Chipset PCIe Root Port #22
+	a3ed  B460/H410 Chipset PCIe Root Port #23
+	a3ee  B460/H410 Chipset PCIe Root Port #24
+	a3f0  B460/H410 Chipset HD Audio
+	a3f1  B460/H410 Chipset HD Audio
+	a3f2  B460/H410 Chipset HD Audio
+	a3f3  B460/H410 Chipset HD Audio
+	a3f4  B460/H410 Chipset HD Audio
+	a3f5  B460/H410 Chipset HD Audio
+	a3f6  B460/H410 Chipset HD Audio
+	a3f7  B460/H410 Chipset HD Audio
 	a620  6400/6402 Advanced Memory Buffer (AMB)
 	a700  Raptor Lake-S Host Bridge/DRAM Controller
 	a703  Raptor Lake-S Host Bridge/DRAM Controller
@@ -40779,55 +40971,91 @@
 	a7ac  Raptor Lake-U [Intel Graphics]
 	a7ad  Raptor Lake-U [Intel Graphics]
 	a806  Lunar Lake-M LPC/eSPI Controller
+	a807  Core Ultra 200V Series Processors eSPI Controller
+	a820  Core Ultra 200V Series Processors P2SB (8 bit)
+	a821  Core Ultra 200V Series Processors PMC
 	a822  Lunar Lake-M SMbus Controller
-	a823  Lunar Lake-M SPI Controller
-	a824  Lunar Lake-M Trace Hub
-	a825  Lunar Lake-M Serial IO UART Controller #0
-	a826  Lunar Lake-M Serial IO UART Controller #1
-	a827  Lunar Lake-M Serial IO SPI Controller #0
-	a828  Lunar Lake-M HD Audio Controller
-	a830  Lunar Lake-M Serial IO SPI Controller #1
-	a831  Lunar Lake-M Thunderbolt 4 USB Controller
-	a833  Lunar Lake-M Thunderbolt 4 NHI #0
-	a834  Lunar Lake-M Thunderbolt 4 NHI #1
-	a838  Lunar Lake-M PCI Express Root Port #1
-	a839  Lunar Lake-M PCI Express Root Port #2
-	a83a  Lunar Lake-M PCI Express Root Port #3
-	a83b  Lunar Lake-M PCI Express Root Port #4
-	a83c  Lunar Lake-M PCI Express Root Port #5
-	a83d  Lunar Lake-M PCI Express Root Port #6
+	a823  Core Ultra 200V Series Processors SPI (flash) Controller
+	a824  Core Ultra 200V Series Processors Trace Hub
+	a825  Core Ultra 200V Series Processors UART #0
+	a826  Core Ultra 200V Series Processors UART #1
+	a827  Core Ultra 200V Series Processors GSPI #0
+	a828  Core Ultra 200V Series Processors HD Audio
+	a830  Core Ultra 200V Series Processors GSPI #1
+	a831  Core Ultra 200V Series Processors Type-C Subsystem xHCI
+	a833  Core Ultra 200V Series Processors Thunderbolt DMA0
+	a834  Core Ultra 200V Series Processors Thunderbolt DMA1
+	a838  Core Ultra 200V Series Processors PCIe Root Port #1
+	a839  Core Ultra 200V Series Processors PCIe Root Port #2
+	a83a  Core Ultra 200V Series Processors PCIe Root Port #3
+	a83b  Core Ultra 200V Series Processors PCIe Root Port #4
+	a83c  Core Ultra 200V Series Processors PCIe Root Port #5
+	a83d  Core Ultra 200V Series Processors PCIe Root Port #6
 	a840  BE200 Series Wi-Fi 7
-	a845  Lunar Lake-M Integrated Sensor Hub
+	a845  Core Ultra 200V Series Processors Integrated Sensor Hub (ISH)
+	a846  Core Ultra 200V Series Processors GSPI #2
 	a847  Lunar Lake-M UFS Controller
-	a848  Lunar Lake-M Touch Host Controller #0 ID1
-	a849  Lunar Lake-M Touch Host Controller #0 ID2
-	a84a  Lunar Lake-M Touch Host Controller #1 ID1
-	a84b  Lunar Lake-M Touch Host Controller #1 ID2
-	a84e  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #0
-	a84f  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #1
-	a860  Lunar Lake-M Thunderbolt 4 PCI Express Root Port #2
-	a870  Lunar Lake-M CSME HECI #1
-	a873  Lunar Lake-M Keyboard and Text (KT) Redirection
-	a878  Lunar Lake-M Serial IO I2C Controller #0
-	a879  Lunar Lake-M Serial IO I2C Controller #1
-	a87a  Lunar Lake-M Serial IO I2C Controller #2
-	a87b  Lunar Lake-M Serial IO I2C Controller #3
-	a87d  Lunar Lake-M USB 3.2 Gen 2x1 xHCI Host Controller
-	a87f  Lunar Lake-M Shared SRAM
+	a848  Core Ultra 200V Series Processors Touch Host Controller (THC) #0 ID1
+	a849  Core Ultra 200V Series Processors Touch Host Controller (THC) #0 ID2
+	a84a  Core Ultra 200V Series Processors Touch Host Controller (THC) #1 ID1
+	a84b  Core Ultra 200V Series Processors Touch Host Controller (THC) #1 ID2
+	a84c  Core Ultra 200V Series Processors P2SB (16 bit)
+	a84e  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #21
+	a84f  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #22
+	a850  Core Ultra 200V Series Processors I2C #4
+	a851  Core Ultra 200V Series Processors I2C #5
+	a852  Core Ultra 200V Series Processors UART #2
+	a85d  Core Ultra 200V Series Processors CSME HECI #1
+	a85e  Core Ultra 200V Series Processors CSME HECI #2
+	a85f  Core Ultra 200V Series Processors CSME HECI #3
+	a860  Core Ultra 200V Series Processors USB Type-C Subsystem PCIe Root Port #23
+	a862  Core Ultra 200V Series Processors CSME HECI #1
+	a863  Core Ultra 200V Series Processors CSME HECI #2
+	a864  Core Ultra 200V Series Processors CSME HECI #3
+	a870  Core Ultra 200V Series Processors CSME HECI #1 (CSE)
+	a871  Core Ultra 200V Series Processors CSME HECI #2 (CSE)
+	a872  Core Ultra 200V Series Processors CSME IDE Redirection (IDE-R)
+	a873  Core Ultra 200V Series Processors CSME Keyboard and Text (KT) Redirection
+	a874  Core Ultra 200V Series Processors CSME HECI #3 (CSE)
+	a875  Core Ultra 200V Series Processors CSME HECI #4 (CSE)
+	a877  Core Ultra 200V Series Processors I3C #2
+	a878  Core Ultra 200V Series Processors I2C #0
+	a879  Core Ultra 200V Series Processors I2C #1
+	a87a  Core Ultra 200V Series Processors I2C #2
+	a87b  Core Ultra 200V Series Processors I2C #3
+	a87c  Core Ultra 200V Series Processors I3C #1
+	a87d  Core Ultra 200V Series Processors Standalone xHCI Controller
+	a87f  Core Ultra 200V Series Processors Shared SRAM
 	abc0  Omni-Path Fabric Switch Silicon 100 Series
-	ad0b  Volume Management Device NVMe RAID Controller Intel Corporation
-	ad0d  Arrow Lake-HX Crash Log & Telemetry
-	ad1d  Arrow Lake NPU
+	ad03  Core Ultra 200 Series Processors Dynamic Tuning Technology (DTT)
+	ad0b  Core Ultra 200 Series Processors VMD
+	ad0d  Core Ultra 200 Series Processors Crash Log and Telemetry
+	ad1d  Core Ultra 200 Series Processors NPU
 	ae10  Arrow Lake-HX Direct eSPI Controller
-	ae23  Arrow Lake-HX SPI (flash) Controller
-	ae4c  Arrow Lake-HX Gauss Newton Algorithm (GNA)
-	ae4d  Arrow Lake-HX PCIe Root Port #13
-	ae7f  Arrow Lake-HX Shared SRAM (SOC-S)
-	b002  Panther Lake Host Bridge/DRAM Controller
-	b01d  Panther Lake Innovation Platform Framework Processor Participant
-	b03e  Panther Lake NPU
-	b05d  Panther Lake IPU
-	b07d  Panther Lake Platform Monitoring Technology (PMT)
+	ae20  Core Ultra 200 Series Processors P2SB (SOC-S)
+	ae21  Core Ultra 200 Series Processors PMC (SOC-S)
+	ae22  Core Ultra 200 Series Processors SMBus
+	ae23  Core Ultra 200 Series Processors SPI (flash) Controller
+	ae24  Core Ultra 200 Series Processors Trace Hub
+	ae4c  Core Ultra 200 Series Processors Gauss Newton Algorithm (GNA)
+	ae4d  Core Ultra 200 Series Processors PCIe Root Port #13
+	ae4e  Core Ultra 200 Series Processors PCIe Root Port #14
+	ae4f  Core Ultra 200 Series Processors PCIe Root Port #15
+	ae70  Core Ultra 200 Series Processors CSME HECI #1
+	ae71  Core Ultra 200 Series Processors CSME HECI #2
+	ae74  Core Ultra 200 Series Processors CSME HECI #3
+	ae7f  Core Ultra 200 Series Processors Shared SRAM (SOC-S)
+	b000  Core Ultra Processors (Series 3) PTL-404
+	b001  Core Ultra Processors (Series 3) PTL-H12Xe
+	b002  Core Ultra Processors (Series 3) PTL-H484
+	b003  Core Ultra Processors (Series 3) PTL-204
+	b004  Core Ultra Processors (Series 3) PTL-H444
+	b005  Core Ultra Processors (Series 3) PTL-H444
+	b01d  Core Ultra Processors (Series 3) DTT
+	b02d  Core Ultra Processors (Series 3) IAA
+	b03e  Core Ultra Processors (Series 3) NPU
+	b05d  Core Ultra Processors (Series 3) IPU
+	b07d  Core Ultra Processors (Series 3) Crashlog and Telemetry
 	b080  Panther Lake [Arc B390]
 	b081  Panther Lake [Arc B370]
 	b082  Panther Lake [Arc B390]
@@ -40929,59 +41157,167 @@
 	e221  Battlemage G31 [Intel Graphics]
 	e222  Battlemage G31 [Arc Pro B65]
 	e223  Battlemage G31 [Arc Pro B70]
-	e302  Panther Lake LPC/eSPI Controller
-	e322  Panther Lake SMBus Controller
-	e323  Panther Lake SPI(flash) Controller
-	e325  Panther Lake Serial IO UART Controller #0
-	e326  Panther Lake Serial IO UART Controller #1
-	e327  Panther Lake Serial IO SPI Host Controller #0
-	e328  Panther Lake Smart Sound Technology BUS
-	e330  Panther Lake Serial IO SPI Host Controller #1
-	e331  Panther Lake TCSS USB3 xHCI Controller
-	e333  Panther Lake Thunderbolt 4 NHI #0
-	e334  Panther Lake Thunderbolt 4 NHI #1
-	e338  Panther Lake PCI Express Root Port A1
-	e339  Panther Lake PCI Express Root Port A2
-	e33a  Panther Lake PCI Express Root Port A3
-	e33b  Panther Lake PCI Express Root Port A4
-	e33c  Panther Lake PCI Express Root Port B1
-	e33d  Panther Lake PCI Express Root Port B2
-	e33e  Panther Lake PCI Express Root Port B3
-	e33f  Panther Lake PCI Express Root Port B4
-	e340  Panther Lake PCH CNVi WiFi
+	e300  Core Ultra Processors (Series 3) eSPI
+	e302  Core Ultra Processors (Series 3) eSPI
+	e31f  Core Ultra Processors (Series 3) eSPI
+	e320  Core Ultra Processors (Series 3) P2SB
+	e321  Core Ultra Processors (Series 3) PMC
+	e322  Core Ultra Processors (Series 3) SMBus
+	e323  Core Ultra Processors (Series 3) SPI (flash) Controller
+	e324  Core Ultra Processors (Series 3) Trace Hub
+	e325  Core Ultra Processors (Series 3) UART #0
+	e326  Core Ultra Processors (Series 3) UART #1
+	e327  Core Ultra Processors (Series 3) GSPI #0
+	e328  Core Ultra Processors (Series 3) HD Audio
+	e329  Core Ultra Processors (Series 3) HD Audio
+	e32a  Core Ultra Processors (Series 3) HD Audio
+	e32b  Core Ultra Processors (Series 3) HD Audio
+	e32c  Core Ultra Processors (Series 3) HD Audio
+	e32d  Core Ultra Processors (Series 3) HD Audio
+	e32e  Core Ultra Processors (Series 3) HD Audio
+	e32f  Core Ultra Processors (Series 3) HD Audio
+	e330  Core Ultra Processors (Series 3) GSPI #1
+	e331  Core Ultra Processors (Series 3) Type-C Subsystem xHCI
+	e332  Core Ultra Processors (Series 3) Type-C Subsystem xDCI
+	e333  Core Ultra Processors (Series 3) Thunderbolt DMA0
+	e334  Core Ultra Processors (Series 3) Thunderbolt DMA1
+	e337  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #24
+	e338  Core Ultra Processors (Series 3) PCIe Root Port #1
+	e339  Core Ultra Processors (Series 3) PCIe Root Port #2
+	e33a  Core Ultra Processors (Series 3) PCIe Root Port #3
+	e33b  Core Ultra Processors (Series 3) PCIe Root Port #4
+	e33c  Core Ultra Processors (Series 3) PCIe Root Port #5
+	e33d  Core Ultra Processors (Series 3) PCIe Root Port #6
+	e33e  Core Ultra Processors (Series 3) PCIe Root Port #7
+	e33f  Core Ultra Processors (Series 3) PCIe Root Port #8
+	e340  Core Ultra Processors (Series 3) CNVi Wi-Fi
 		8086 0094  Wi-Fi 6E AX211 160MHz
-	e34e  Panther Lake Thunderbolt 4 PCI Express Root Port #0
-	e35d  Panther Lake CSME HECI #1
-	e360  Panther Lake Thunderbolt 4 PCI Express Root Port #2
-	e361  Panther Lake PCI Express Root Port C1
-	e362  Panther Lake Primary to Sideband (P2SB) Bridge IOE
-	e363  Panther Lake PCI Express Root Port C3
-	e364  Panther Lake PCI Express Root Port C4
-	e365  Panther Lake PCI Express Root Port D1
-	e366  Panther Lake PCI Express Root Port D2
+	e341  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e342  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e343  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e344  Core Ultra Processors (Series 3) IEH #0
+	e345  Core Ultra Processors (Series 3) ISH
+	e346  Core Ultra Processors (Series 3) GSPI #2
+	e348  Core Ultra Processors (Series 3) THC #0 ID1
+	e349  Core Ultra Processors (Series 3) THC #0 ID2
+	e34a  Core Ultra Processors (Series 3) THC #1 ID1
+	e34b  Core Ultra Processors (Series 3) THC #1 ID2
+	e34c  Core Ultra Processors (Series 3) P2SB
+	e34d  Core Ultra Processors (Series 3) IEH #1
+	e34e  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #21
+	e34f  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #22
+	e350  Core Ultra Processors (Series 3) I2C #4
+	e351  Core Ultra Processors (Series 3) I2C #5
+	e352  Core Ultra Processors (Series 3) UART #2
+	e35c  Core Ultra Processors (Series 3) PCIe Root Port #10
+	e35d  Core Ultra Processors (Series 3) CSME HECI #1
+	e35e  Core Ultra Processors (Series 3) CSME HECI #2
+	e35f  Core Ultra Processors (Series 3) CSME HECI #3
+	e360  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #23
+	e361  Core Ultra Processors (Series 3) PCIe Root Port #9
+	e362  Core Ultra Processors (Series 3) CSME HECI #1
+	e363  Core Ultra Processors (Series 3) CSME HECI #2
+	e364  Core Ultra Processors (Series 3) CSME HECI #3
+	e365  Core Ultra Processors (Series 3) PCIe Root Port #11
+	e366  Core Ultra Processors (Series 3) PCIe Root Port #12
 	e367  Panther Lake PCI Express Root Port D3
 	e368  Panther Lake PCI Express Root Port D4
 	e369  Panther Lake PCI Express Root Port D5
 	e36a  Panther Lake PCI Express Root Port D6
 	e36b  Panther Lake PCI Express Root Port D7
 	e36c  Panther Lake PCI Express Root Port D8
-	e36f  Panther Lake I3C Host Controller #0
-	e370  Panther Lake MEI Controller
-	e376  Panther Lake Bluetooth PCI Enumerator
-	e378  Panther Lake Serial IO I2C Controller #0
-	e379  Panther Lake Serial IO I2C Controller #1
-	e37a  Panther Lake Serial IO I2C Controller #2
-	e37b  Panther Lake Serial IO I2C Controller #3
-	e37c  Panther Lake I3C Host Controller #1
-	e37d  Panther Lake USB 3.2 xHCI Controller
-	e37f  Panther Lake Shared SRAM
-	e431  Panther Lake USB 3.2 xHCI Controller
-	e434  Panther Lake Thunderbolt 4 NHI #2
-	e440  Panther Lake PCH CNVi WiFi
+	e36f  Core Ultra Processors (Series 3) I3C #2
+	e370  Core Ultra Processors (Series 3) CSME HECI #1 (CSE)
+	e371  Core Ultra Processors (Series 3) CSME HECI #2 (CSE)
+	e372  Core Ultra Processors (Series 3) CSME IDE Redirection (IDE-R)
+	e373  Core Ultra Processors (Series 3) CSME Keyboard and Text (KT) Redirection
+	e374  Core Ultra Processors (Series 3) CSME HECI #3 (CSE)
+	e375  Core Ultra Processors (Series 3) CSME HECI #4 (CSE)
+	e376  Core Ultra Processors (Series 3) CNVi Bluetooth
+	e378  Core Ultra Processors (Series 3) I2C #0
+	e379  Core Ultra Processors (Series 3) I2C #1
+	e37a  Core Ultra Processors (Series 3) I2C #2
+	e37b  Core Ultra Processors (Series 3) I2C #3
+	e37c  Core Ultra Processors (Series 3) I3C #1
+	e37d  Core Ultra Processors (Series 3) Standalone xHCI Controller
+	e37e  Core Ultra Processors (Series 3) Standalone USB Device Controller
+	e37f  Core Ultra Processors (Series 3) Shared SRAM
+	e400  Core Ultra Processors (Series 3) eSPI
+	e41f  Core Ultra Processors (Series 3) eSPI
+	e420  Core Ultra Processors (Series 3) P2SB
+	e421  Core Ultra Processors (Series 3) PMC
+	e422  Core Ultra Processors (Series 3) SMBus
+	e423  Core Ultra Processors (Series 3) SPI (flash) Controller
+	e424  Core Ultra Processors (Series 3) Trace Hub
+	e425  Core Ultra Processors (Series 3) UART #0
+	e426  Core Ultra Processors (Series 3) UART #1
+	e427  Core Ultra Processors (Series 3) GSPI #0
+	e428  Core Ultra Processors (Series 3) HD Audio
+	e429  Core Ultra Processors (Series 3) HD Audio
+	e42a  Core Ultra Processors (Series 3) HD Audio
+	e42b  Core Ultra Processors (Series 3) HD Audio
+	e42c  Core Ultra Processors (Series 3) HD Audio
+	e42d  Core Ultra Processors (Series 3) HD Audio
+	e42e  Core Ultra Processors (Series 3) HD Audio
+	e42f  Core Ultra Processors (Series 3) HD Audio
+	e430  Core Ultra Processors (Series 3) GSPI #1
+	e431  Core Ultra Processors (Series 3) Type-C Subsystem xHCI
+	e432  Core Ultra Processors (Series 3) Type-C Subsystem xDCI
+	e433  Core Ultra Processors (Series 3) Thunderbolt DMA0
+	e434  Core Ultra Processors (Series 3) Thunderbolt DMA1
+	e437  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #24
+	e438  Core Ultra Processors (Series 3) PCIe Root Port #1
+	e439  Core Ultra Processors (Series 3) PCIe Root Port #2
+	e43a  Core Ultra Processors (Series 3) PCIe Root Port #3
+	e43b  Core Ultra Processors (Series 3) PCIe Root Port #4
+	e43c  Core Ultra Processors (Series 3) PCIe Root Port #5
+	e43d  Core Ultra Processors (Series 3) PCIe Root Port #6
+	e43e  Core Ultra Processors (Series 3) PCIe Root Port #7
+	e43f  Core Ultra Processors (Series 3) PCIe Root Port #8
+	e440  Core Ultra Processors (Series 3) CNVi Wi-Fi
 		8086 0114  Wi-Fi 7 BE211 320MHz
-	e476  Panther Lake Bluetooth PCI Enumerator
-	e47b  Serial IO I2C Host Controller - E47B
-	e47d  Panther Lake USB 3.2 xHCI Controller
+	e441  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e442  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e443  Core Ultra Processors (Series 3) CNVi Wi-Fi
+	e444  Core Ultra Processors (Series 3) IEH #0
+	e445  Core Ultra Processors (Series 3) ISH
+	e446  Core Ultra Processors (Series 3) GSPI #2
+	e448  Core Ultra Processors (Series 3) THC #0 ID1
+	e449  Core Ultra Processors (Series 3) THC #0 ID2
+	e44a  Core Ultra Processors (Series 3) THC #1 ID1
+	e44b  Core Ultra Processors (Series 3) THC #1 ID2
+	e44c  Core Ultra Processors (Series 3) P2SB
+	e44d  Core Ultra Processors (Series 3) IEH #1
+	e44e  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #21
+	e44f  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #22
+	e450  Core Ultra Processors (Series 3) I2C #4
+	e451  Core Ultra Processors (Series 3) I2C #5
+	e452  Core Ultra Processors (Series 3) UART #2
+	e45c  Core Ultra Processors (Series 3) PCIe Root Port #10
+	e45d  Core Ultra Processors (Series 3) CSME HECI #1
+	e45e  Core Ultra Processors (Series 3) CSME HECI #2
+	e45f  Core Ultra Processors (Series 3) CSME HECI #3
+	e460  Core Ultra Processors (Series 3) USB Type-C Subsystem PCIe Root Port #23
+	e461  Core Ultra Processors (Series 3) PCIe Root Port #9
+	e462  Core Ultra Processors (Series 3) CSME HECI #1
+	e463  Core Ultra Processors (Series 3) CSME HECI #2
+	e464  Core Ultra Processors (Series 3) CSME HECI #3
+	e46f  Core Ultra Processors (Series 3) I3C #2
+	e470  Core Ultra Processors (Series 3) CSME HECI #1 (CSE)
+	e471  Core Ultra Processors (Series 3) CSME HECI #2 (CSE)
+	e472  Core Ultra Processors (Series 3) CSME IDE Redirection (IDE-R)
+	e473  Core Ultra Processors (Series 3) CSME Keyboard and Text (KT) Redirection
+	e474  Core Ultra Processors (Series 3) CSME HECI #3 (CSE)
+	e475  Core Ultra Processors (Series 3) CSME HECI #4 (CSE)
+	e476  Core Ultra Processors (Series 3) CNVi Bluetooth
+	e478  Core Ultra Processors (Series 3) I2C #0
+	e479  Core Ultra Processors (Series 3) I2C #1
+	e47a  Core Ultra Processors (Series 3) I2C #2
+	e47b  Core Ultra Processors (Series 3) I2C #3
+	e47c  Core Ultra Processors (Series 3) I3C #1
+	e47d  Core Ultra Processors (Series 3) Standalone xHCI Controller
+	e47e  Core Ultra Processors (Series 3) Standalone USB Device Controller
+	e47f  Core Ultra Processors (Series 3) Shared SRAM
 	f1a5  SSD 600P Series
 		8086 390a  SSDPEKKW256G7 256GB
 	f1a6  SSD DC P4101/Pro 7600p/760p/E 6100p Series
@@ -41151,6 +41487,9 @@
 	1080  Ethernet Controller N10 Series Virtual Function
 	1081  Ethernet Controller N400 Series Virtual Function
 	1083  Ethernet Controller N400 Series Virtual Function
+	8208  Ethernet Controller N210M for 1GbE 1-port RJ45
+	8209  Ethernet Controller N210 Series Virtual Function
+	820a  Ethernet Controller N210L for 1GbE 1-port RJ45
 	8308  Ethernet Controller N500 Series for 1GbE (Quad-port, Copper RJ45)
 # NIC-ETH3M0T-3S-4P Quad-Port RJ45 Adapter for OCP 3.0
 		193d 1088  NIC-ETH3M0T-3S-4P
@@ -41163,10 +41502,16 @@
 	8500  Ethernet Controller N20 Series for 25GbE
 		8848 0800  Ethernet Network Adapter N20 for 25GbE SFP28
 		8848 8800  Ethernet Network Adapter N20 for RDMA 25GbE SFP28 2-port
+		8848 c800  Ethernet Network Adapter N20 for RDMA 25GbE SFP28 2-port OCP 3.0
 	8501  Ethernet Controller N20 Series for 100GbE
 		8848 8800  Ethernet Network Adapter N20 for RDMA 100GbE QSFP28 2-port
 	8502  Ethernet Controller N20 Series for 40GbE
 		8848 8800  Ethernet Network Adapter N20 for RDMA 40GbE QSFP+ 2-port
+	8503  Ethernet Controller N20 Series Virtual Function
+	8507  Ethernet Controller B-Series for 25GbE
+	8508  Ethernet Controller B-Series for 100GbE
+	8509  Ethernet Controller B-Series for 40GbE
+	850a  Ethernet Controller B-Series Virtual Function
 8866  T-Square Design Inc.
 8888  Silicon Magic
 	8504  AVMatrix VC42 4-port HDMI Capture

--- a/usb.ids
+++ b/usb.ids
@@ -9,8 +9,8 @@
 #	The latest version can be obtained from
 #		http://www.linux-usb.org/usb.ids
 #
-# Version: 2025.12.13
-# Date:    2025-12-13 20:34:01
+# Version: 2026.06.26
+# Date:    2026-06-26 20:34:02
 #
 
 # Vendors, devices and interfaces. Please keep sorted.
@@ -11319,6 +11319,7 @@
 	4500  LV-20 Digital Camera
 	6101  fx-9750gII
 	6102  fx-CP400
+	6103  fx-CG50
 	6801  PL-40R
 	6802  MIDI Keyboard
 	6803  CTK-3500 (MIDI keyboard)
@@ -13057,6 +13058,7 @@
 	5804  BCM5880 Secure Applications Processor with fingerprint swipe sensor
 	5832  BCM5880 Secure Applications Processor Smartcard reader
 	5843  BCM58200 ControlVault 3 (FingerPrint sensor + Contacted SmartCard)
+	5865  Fingerprint Reader (Dell Control Vault)
 	6300  Pirelli Remote NDIS Device
 	6410  BCM20703A1 Bluetooth 4.1 + LE
 	bd11  BCM4320 802.11bg Wireless Adapter


### PR DESCRIPTION
Automated monthly update of hardware IDs to version 0.409

## Updated Files
- PCI IDs: 2026-07-01
- USB IDs: 2026-06-26
- Vendor IDs (OUI/IAB/PNP): Updated

## PCI Changes
```
old vendor count: 2502
new vendor count: 2503
vendors added:    1
vendors removed:  0
vendors renamed:  1
devices added:    284
devices removed:  7
devices renamed:  154
```

## Testing
- [x] `make check` passes
- [x] Packit builds successful
- [x] Tests pass on all targets

🤖 Generated by monthly-update.py automation

## Summary by Sourcery

Bump hwdata to version 0.409 and refresh bundled hardware identification databases.

New Features:
- Include updated PCI, USB, and vendor (OUI/IAB/PNP) identifier data files for July 2026.

Enhancements:
- Record the July 2026 hardware ID refresh in the RPM spec changelog.